### PR TITLE
Move to a single range read with prefix and predicate

### DIFF
--- a/pkg/sloop/processing/eventcount_test.go
+++ b/pkg/sloop/processing/eventcount_test.go
@@ -173,7 +173,7 @@ func Test_EventCountTable_DupeEventSameResults(t *testing.T) {
 func findEventKeys(tables typed.Tables) ([]string, error) {
 	var foundKeys []string
 	err := tables.Db().View(func(txn badgerwrap.Txn) error {
-		ret, _, err2 := tables.EventCountTable().RangeRead(txn, func(s string) bool { return true }, nil, someEventWatchTs.Add(-1*time.Hour), someEventWatchTs.Add(time.Hour))
+		ret, _, err2 := tables.EventCountTable().RangeRead(txn, nil, func(s string) bool { return true }, nil, someEventWatchTs.Add(-1*time.Hour), someEventWatchTs.Add(time.Hour))
 		if err2 != nil {
 			return err2
 		}

--- a/pkg/sloop/queries/eventquery.go
+++ b/pkg/sloop/queries/eventquery.go
@@ -37,7 +37,7 @@ func GetEventData(params url.Values, t typed.Tables, startTime time.Time, endTim
 		var err2 error
 		var stats typed.RangeReadStats
 		// TODO: In addition to isEventValInTimeRange we need to also crack open the payload and check the involvedObject kind (+namespace, name, uuid)
-		watchEvents, stats, err2 = t.WatchTable().RangeRead(txn, paramEventDataFn(params), isEventValInTimeRange(startTime, endTime), startTime, endTime)
+		watchEvents, stats, err2 = t.WatchTable().RangeRead(txn, nil, paramEventDataFn(params), isEventValInTimeRange(startTime, endTime), startTime, endTime)
 		if err2 != nil {
 			return err2
 		}

--- a/pkg/sloop/queries/queryd3heatmap.go
+++ b/pkg/sloop/queries/queryd3heatmap.go
@@ -115,19 +115,19 @@ func getRawDataFromStore(params url.Values, t typed.Tables, startTime time.Time,
 	err := t.Db().View(func(txn badgerwrap.Txn) error {
 		var err2 error
 		var stats typed.RangeReadStats
-		ret.Events, stats, err2 = t.EventCountTable().RangeRead(txn, paramEventCountSumFn(params), nil, startTime, endTime)
+		ret.Events, stats, err2 = t.EventCountTable().RangeRead(txn, nil, paramEventCountSumFn(params), nil, startTime, endTime)
 		if err2 != nil {
 			return err2
 		}
 		stats.Log(requestId)
 
-		ret.Resources, stats, err2 = t.ResourceSummaryTable().RangeRead(txn, paramFilterResSumFn(params), nil, startTime, endTime)
+		ret.Resources, stats, err2 = t.ResourceSummaryTable().RangeRead(txn, nil, paramFilterResSumFn(params), nil, startTime, endTime)
 		if err2 != nil {
 			return err2
 		}
 		stats.Log(requestId)
 
-		ret.WatchActivity, stats, err2 = t.WatchActivityTable().RangeRead(txn, paramFilterWatchActivityFn(params), nil, startTime, endTime)
+		ret.WatchActivity, stats, err2 = t.WatchActivityTable().RangeRead(txn, nil, paramFilterWatchActivityFn(params), nil, startTime, endTime)
 		if err2 != nil {
 			return err2
 		}

--- a/pkg/sloop/queries/queryfilter.go
+++ b/pkg/sloop/queries/queryfilter.go
@@ -25,7 +25,7 @@ func NamespaceQuery(params url.Values, tables typed.Tables, startTime time.Time,
 	err := tables.Db().View(func(txn badgerwrap.Txn) error {
 		var err2 error
 		var stats typed.RangeReadStats
-		resourcesNs, stats, err2 = tables.ResourceSummaryTable().RangeRead(txn, isNamespace, nil, startTime, endTime)
+		resourcesNs, stats, err2 = tables.ResourceSummaryTable().RangeRead(txn, nil, isNamespace, nil, startTime, endTime)
 		if err2 != nil {
 			return err2
 		}
@@ -48,7 +48,7 @@ func NamespaceQuery(params url.Values, tables typed.Tables, startTime time.Time,
 func KindQuery(params url.Values, tables typed.Tables, startTime time.Time, endTime time.Time, requestId string) ([]byte, error) {
 	kindExists := make(map[string]bool)
 	err := tables.Db().View(func(txn badgerwrap.Txn) error {
-		_, stats, err2 := tables.ResourceSummaryTable().RangeRead(txn, isKind(kindExists), nil, startTime, endTime)
+		_, stats, err2 := tables.ResourceSummaryTable().RangeRead(txn, nil, isKind(kindExists), nil, startTime, endTime)
 		if err2 != nil {
 			return err2
 		}

--- a/pkg/sloop/queries/respayloadquery.go
+++ b/pkg/sloop/queries/respayloadquery.go
@@ -25,7 +25,7 @@ func GetResPayload(params url.Values, t typed.Tables, startTime time.Time, endTi
 	err := t.Db().View(func(txn badgerwrap.Txn) error {
 		var err2 error
 		var stats typed.RangeReadStats
-		watchRes, _, err2 = t.WatchTable().RangeRead(txn, paramResPayloadFn(params), isResPayloadInTimeRange(startTime, endTime), startTime, endTime)
+		watchRes, _, err2 = t.WatchTable().RangeRead(txn, nil, paramResPayloadFn(params), isResPayloadInTimeRange(startTime, endTime), startTime, endTime)
 		if err2 != nil {
 			return err2
 		}

--- a/pkg/sloop/queries/ressumquery.go
+++ b/pkg/sloop/queries/ressumquery.go
@@ -31,7 +31,7 @@ func GetResSummaryData(params url.Values, t typed.Tables, startTime time.Time, e
 	err := t.Db().View(func(txn badgerwrap.Txn) error {
 		var err2 error
 		var stats typed.RangeReadStats
-		resSummaries, stats, err2 = t.ResourceSummaryTable().RangeRead(txn, paramFilterResSumFn(params), isResSummaryValInTimeRange(startTime, endTime), startTime, endTime)
+		resSummaries, stats, err2 = t.ResourceSummaryTable().RangeRead(txn, nil, paramFilterResSumFn(params), isResSummaryValInTimeRange(startTime, endTime), startTime, endTime)
 		if err2 != nil {
 			return err2
 		}

--- a/pkg/sloop/store/typed/eventcounttablegen.go
+++ b/pkg/sloop/store/typed/eventcounttablegen.go
@@ -132,71 +132,6 @@ func (t *ResourceEventCountsTable) GetMinMaxPartitions(txn badgerwrap.Txn) (bool
 	return true, minKey.PartitionId, maxKey.PartitionId
 }
 
-//TODO: will be replaced by GetPartitionsFromTimeRange in future
-func (t *ResourceEventCountsTable) RangeRead(
-	txn badgerwrap.Txn,
-	keyPredicateFn func(string) bool,
-	valPredicateFn func(*ResourceEventCounts) bool,
-	startTime time.Time,
-	endTime time.Time) (map[EventCountKey]*ResourceEventCounts, RangeReadStats, error) {
-
-	resources := map[EventCountKey]*ResourceEventCounts{}
-
-	keyPrefix := "/" + t.tableName + "/"
-	iterOpt := badger.DefaultIteratorOptions
-	iterOpt.Prefix = []byte(keyPrefix)
-	itr := txn.NewIterator(iterOpt)
-	defer itr.Close()
-
-	startPartition := untyped.GetPartitionId(startTime)
-	endPartition := untyped.GetPartitionId(endTime)
-	startPartitionPrefix := keyPrefix + startPartition + "/"
-
-	stats := RangeReadStats{}
-	before := time.Now()
-
-	lastPartition := ""
-	for itr.Seek([]byte(startPartitionPrefix)); itr.ValidForPrefix([]byte(keyPrefix)); itr.Next() {
-		stats.RowsVisitedCount += 1
-		if !keyPredicateFn(string(itr.Item().Key())) {
-			continue
-		}
-		stats.RowsPassedKeyPredicateCount += 1
-
-		key := EventCountKey{}
-		err := key.Parse(string(itr.Item().Key()))
-		if err != nil {
-			return nil, stats, err
-		}
-		if key.PartitionId != lastPartition {
-			stats.PartitionCount += 1
-			lastPartition = key.PartitionId
-		}
-		// partitions are zero padded to 12 digits so we can compare them lexicographically
-		if key.PartitionId > endPartition {
-			// end of range
-			break
-		}
-		valueBytes, err := itr.Item().ValueCopy([]byte{})
-		if err != nil {
-			return nil, stats, err
-		}
-		retValue := &ResourceEventCounts{}
-		err = proto.Unmarshal(valueBytes, retValue)
-		if err != nil {
-			return nil, stats, err
-		}
-		if valPredicateFn != nil && !valPredicateFn(retValue) {
-			continue
-		}
-		stats.RowsPassedValuePredicateCount += 1
-		resources[key] = retValue
-	}
-	stats.Elapsed = time.Since(before)
-	stats.TableName = (&EventCountKey{}).TableName()
-	return resources, stats, nil
-}
-
 //todo: need to add unit test
 func (t *ResourceEventCountsTable) GetUniquePartitionList(txn badgerwrap.Txn) ([]string, error) {
 	resources := []string{}
@@ -273,8 +208,8 @@ func (t *ResourceEventCountsTable) getLastMatchingKeyInPartition(txn badgerwrap.
 }
 
 //todo: add unit tests
-func (t *ResourceEventCountsTable) RangeReadPerPartition(txn badgerwrap.Txn, keyPrefix *EventCountKey,
-	valPredicateFn func(*ResourceEventCounts) bool, startTime time.Time, endTime time.Time) (map[EventCountKey]*ResourceEventCounts, RangeReadStats, error) {
+func (t *ResourceEventCountsTable) RangeRead(txn badgerwrap.Txn, keyPrefix *EventCountKey,
+	keyPredicateFn func(string) bool, valPredicateFn func(*ResourceEventCounts) bool, startTime time.Time, endTime time.Time) (map[EventCountKey]*ResourceEventCounts, RangeReadStats, error) {
 	resources := map[EventCountKey]*ResourceEventCounts{}
 
 	stats := RangeReadStats{}
@@ -306,6 +241,11 @@ func (t *ResourceEventCountsTable) RangeReadPerPartition(txn badgerwrap.Txn, key
 		//in most cases, we should only hit one result per partition
 		for itr.Seek([]byte(seekStr)); itr.ValidForPrefix([]byte(seekStr)); itr.Next() {
 			stats.RowsVisitedCount += 1
+			if keyPredicateFn != nil {
+				if !keyPredicateFn(string(itr.Item().Key())) {
+					continue
+				}
+			}
 			key := EventCountKey{}
 			err := key.Parse(string(itr.Item().Key()))
 			if err != nil {

--- a/pkg/sloop/store/typed/eventcounttablegen_test.go
+++ b/pkg/sloop/store/typed/eventcounttablegen_test.go
@@ -13,6 +13,7 @@ package typed
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 	"time"
@@ -20,7 +21,6 @@ import (
 	"github.com/dgraph-io/badger"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped/badgerwrap"
-	"github.com/stretchr/testify/assert"
 )
 
 func helper_ResourceEventCounts_ShouldSkip() bool {

--- a/pkg/sloop/store/typed/resourcesummarytable_test.go
+++ b/pkg/sloop/store/typed/resourcesummarytable_test.go
@@ -103,7 +103,7 @@ func Test_ResourceSummary_RangeRead(t *testing.T) {
 	var retval map[ResourceSummaryKey]*ResourceSummary
 	err = b.View(func(txn badgerwrap.Txn) error {
 		var txerr error
-		retval, _, txerr = wt.RangeRead(txn, func(k string) bool { return true }, func(r *ResourceSummary) bool { return true }, someTs, someTs)
+		retval, _, txerr = wt.RangeRead(txn, nil, func(k string) bool { return true }, func(r *ResourceSummary) bool { return true }, someTs, someTs)
 		if txerr != nil {
 			return txerr
 		}
@@ -146,7 +146,7 @@ func Test_ResourceSummary_RangeReadWithKeyPredicate(t *testing.T) {
 	var retval map[ResourceSummaryKey]*ResourceSummary
 	err = b.View(func(txn badgerwrap.Txn) error {
 		var txerr error
-		retval, _, txerr = wt.RangeRead(txn, func(k string) bool {
+		retval, _, txerr = wt.RangeRead(txn, nil, func(k string) bool {
 			key := &ResourceSummaryKey{}
 			err2 := key.Parse(k)
 			assert.Nil(t, err2)
@@ -256,7 +256,7 @@ func Test_ResourceSummary_RangeReadWithTimeRange(t *testing.T) {
 	err := db.View(func(txn badgerwrap.Txn) error {
 		var txerr error
 		// someTs starts with 4 minutes, subtract 5 minutes to not include partitions above (someTs + 2hours)
-		retval, _, txerr = rst.RangeRead(txn, func(k string) bool { return true }, func(r *ResourceSummary) bool { return true }, someTs.Add(1*time.Hour), someTs.Add(2*time.Hour-5*time.Minute))
+		retval, _, txerr = rst.RangeRead(txn, nil, func(k string) bool { return true }, func(r *ResourceSummary) bool { return true }, someTs.Add(1*time.Hour), someTs.Add(2*time.Hour-5*time.Minute))
 		if txerr != nil {
 			return txerr
 		}

--- a/pkg/sloop/store/typed/resourcesummarytablegen_test.go
+++ b/pkg/sloop/store/typed/resourcesummarytablegen_test.go
@@ -13,6 +13,7 @@ package typed
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 	"time"
@@ -20,7 +21,6 @@ import (
 	"github.com/dgraph-io/badger"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped/badgerwrap"
-	"github.com/stretchr/testify/assert"
 )
 
 func helper_ResourceSummary_ShouldSkip() bool {

--- a/pkg/sloop/store/typed/watchactivitytablegen.go
+++ b/pkg/sloop/store/typed/watchactivitytablegen.go
@@ -132,71 +132,6 @@ func (t *WatchActivityTable) GetMinMaxPartitions(txn badgerwrap.Txn) (bool, stri
 	return true, minKey.PartitionId, maxKey.PartitionId
 }
 
-//TODO: will be replaced by GetPartitionsFromTimeRange in future
-func (t *WatchActivityTable) RangeRead(
-	txn badgerwrap.Txn,
-	keyPredicateFn func(string) bool,
-	valPredicateFn func(*WatchActivity) bool,
-	startTime time.Time,
-	endTime time.Time) (map[WatchActivityKey]*WatchActivity, RangeReadStats, error) {
-
-	resources := map[WatchActivityKey]*WatchActivity{}
-
-	keyPrefix := "/" + t.tableName + "/"
-	iterOpt := badger.DefaultIteratorOptions
-	iterOpt.Prefix = []byte(keyPrefix)
-	itr := txn.NewIterator(iterOpt)
-	defer itr.Close()
-
-	startPartition := untyped.GetPartitionId(startTime)
-	endPartition := untyped.GetPartitionId(endTime)
-	startPartitionPrefix := keyPrefix + startPartition + "/"
-
-	stats := RangeReadStats{}
-	before := time.Now()
-
-	lastPartition := ""
-	for itr.Seek([]byte(startPartitionPrefix)); itr.ValidForPrefix([]byte(keyPrefix)); itr.Next() {
-		stats.RowsVisitedCount += 1
-		if !keyPredicateFn(string(itr.Item().Key())) {
-			continue
-		}
-		stats.RowsPassedKeyPredicateCount += 1
-
-		key := WatchActivityKey{}
-		err := key.Parse(string(itr.Item().Key()))
-		if err != nil {
-			return nil, stats, err
-		}
-		if key.PartitionId != lastPartition {
-			stats.PartitionCount += 1
-			lastPartition = key.PartitionId
-		}
-		// partitions are zero padded to 12 digits so we can compare them lexicographically
-		if key.PartitionId > endPartition {
-			// end of range
-			break
-		}
-		valueBytes, err := itr.Item().ValueCopy([]byte{})
-		if err != nil {
-			return nil, stats, err
-		}
-		retValue := &WatchActivity{}
-		err = proto.Unmarshal(valueBytes, retValue)
-		if err != nil {
-			return nil, stats, err
-		}
-		if valPredicateFn != nil && !valPredicateFn(retValue) {
-			continue
-		}
-		stats.RowsPassedValuePredicateCount += 1
-		resources[key] = retValue
-	}
-	stats.Elapsed = time.Since(before)
-	stats.TableName = (&WatchActivityKey{}).TableName()
-	return resources, stats, nil
-}
-
 //todo: need to add unit test
 func (t *WatchActivityTable) GetUniquePartitionList(txn badgerwrap.Txn) ([]string, error) {
 	resources := []string{}
@@ -273,8 +208,8 @@ func (t *WatchActivityTable) getLastMatchingKeyInPartition(txn badgerwrap.Txn, c
 }
 
 //todo: add unit tests
-func (t *WatchActivityTable) RangeReadPerPartition(txn badgerwrap.Txn, keyPrefix *WatchActivityKey,
-	valPredicateFn func(*WatchActivity) bool, startTime time.Time, endTime time.Time) (map[WatchActivityKey]*WatchActivity, RangeReadStats, error) {
+func (t *WatchActivityTable) RangeRead(txn badgerwrap.Txn, keyPrefix *WatchActivityKey,
+	keyPredicateFn func(string) bool, valPredicateFn func(*WatchActivity) bool, startTime time.Time, endTime time.Time) (map[WatchActivityKey]*WatchActivity, RangeReadStats, error) {
 	resources := map[WatchActivityKey]*WatchActivity{}
 
 	stats := RangeReadStats{}
@@ -306,6 +241,11 @@ func (t *WatchActivityTable) RangeReadPerPartition(txn badgerwrap.Txn, keyPrefix
 		//in most cases, we should only hit one result per partition
 		for itr.Seek([]byte(seekStr)); itr.ValidForPrefix([]byte(seekStr)); itr.Next() {
 			stats.RowsVisitedCount += 1
+			if keyPredicateFn != nil {
+				if !keyPredicateFn(string(itr.Item().Key())) {
+					continue
+				}
+			}
 			key := WatchActivityKey{}
 			err := key.Parse(string(itr.Item().Key()))
 			if err != nil {

--- a/pkg/sloop/store/typed/watchactivitytablegen_test.go
+++ b/pkg/sloop/store/typed/watchactivitytablegen_test.go
@@ -13,6 +13,7 @@ package typed
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 	"time"
@@ -20,7 +21,6 @@ import (
 	"github.com/dgraph-io/badger"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped/badgerwrap"
-	"github.com/stretchr/testify/assert"
 )
 
 func helper_WatchActivity_ShouldSkip() bool {

--- a/pkg/sloop/store/typed/watchtablegen.go
+++ b/pkg/sloop/store/typed/watchtablegen.go
@@ -132,71 +132,6 @@ func (t *KubeWatchResultTable) GetMinMaxPartitions(txn badgerwrap.Txn) (bool, st
 	return true, minKey.PartitionId, maxKey.PartitionId
 }
 
-//TODO: will be replaced by GetPartitionsFromTimeRange in future
-func (t *KubeWatchResultTable) RangeRead(
-	txn badgerwrap.Txn,
-	keyPredicateFn func(string) bool,
-	valPredicateFn func(*KubeWatchResult) bool,
-	startTime time.Time,
-	endTime time.Time) (map[WatchTableKey]*KubeWatchResult, RangeReadStats, error) {
-
-	resources := map[WatchTableKey]*KubeWatchResult{}
-
-	keyPrefix := "/" + t.tableName + "/"
-	iterOpt := badger.DefaultIteratorOptions
-	iterOpt.Prefix = []byte(keyPrefix)
-	itr := txn.NewIterator(iterOpt)
-	defer itr.Close()
-
-	startPartition := untyped.GetPartitionId(startTime)
-	endPartition := untyped.GetPartitionId(endTime)
-	startPartitionPrefix := keyPrefix + startPartition + "/"
-
-	stats := RangeReadStats{}
-	before := time.Now()
-
-	lastPartition := ""
-	for itr.Seek([]byte(startPartitionPrefix)); itr.ValidForPrefix([]byte(keyPrefix)); itr.Next() {
-		stats.RowsVisitedCount += 1
-		if !keyPredicateFn(string(itr.Item().Key())) {
-			continue
-		}
-		stats.RowsPassedKeyPredicateCount += 1
-
-		key := WatchTableKey{}
-		err := key.Parse(string(itr.Item().Key()))
-		if err != nil {
-			return nil, stats, err
-		}
-		if key.PartitionId != lastPartition {
-			stats.PartitionCount += 1
-			lastPartition = key.PartitionId
-		}
-		// partitions are zero padded to 12 digits so we can compare them lexicographically
-		if key.PartitionId > endPartition {
-			// end of range
-			break
-		}
-		valueBytes, err := itr.Item().ValueCopy([]byte{})
-		if err != nil {
-			return nil, stats, err
-		}
-		retValue := &KubeWatchResult{}
-		err = proto.Unmarshal(valueBytes, retValue)
-		if err != nil {
-			return nil, stats, err
-		}
-		if valPredicateFn != nil && !valPredicateFn(retValue) {
-			continue
-		}
-		stats.RowsPassedValuePredicateCount += 1
-		resources[key] = retValue
-	}
-	stats.Elapsed = time.Since(before)
-	stats.TableName = (&WatchTableKey{}).TableName()
-	return resources, stats, nil
-}
-
 //todo: need to add unit test
 func (t *KubeWatchResultTable) GetUniquePartitionList(txn badgerwrap.Txn) ([]string, error) {
 	resources := []string{}
@@ -273,8 +208,8 @@ func (t *KubeWatchResultTable) getLastMatchingKeyInPartition(txn badgerwrap.Txn,
 }
 
 //todo: add unit tests
-func (t *KubeWatchResultTable) RangeReadPerPartition(txn badgerwrap.Txn, keyPrefix *WatchTableKey,
-	valPredicateFn func(*KubeWatchResult) bool, startTime time.Time, endTime time.Time) (map[WatchTableKey]*KubeWatchResult, RangeReadStats, error) {
+func (t *KubeWatchResultTable) RangeRead(txn badgerwrap.Txn, keyPrefix *WatchTableKey,
+	keyPredicateFn func(string) bool, valPredicateFn func(*KubeWatchResult) bool, startTime time.Time, endTime time.Time) (map[WatchTableKey]*KubeWatchResult, RangeReadStats, error) {
 	resources := map[WatchTableKey]*KubeWatchResult{}
 
 	stats := RangeReadStats{}
@@ -306,6 +241,11 @@ func (t *KubeWatchResultTable) RangeReadPerPartition(txn badgerwrap.Txn, keyPref
 		//in most cases, we should only hit one result per partition
 		for itr.Seek([]byte(seekStr)); itr.ValidForPrefix([]byte(seekStr)); itr.Next() {
 			stats.RowsVisitedCount += 1
+			if keyPredicateFn != nil {
+				if !keyPredicateFn(string(itr.Item().Key())) {
+					continue
+				}
+			}
 			key := WatchTableKey{}
 			err := key.Parse(string(itr.Item().Key()))
 			if err != nil {

--- a/pkg/sloop/store/typed/watchtablegen_test.go
+++ b/pkg/sloop/store/typed/watchtablegen_test.go
@@ -13,6 +13,7 @@ package typed
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 	"time"
@@ -20,7 +21,6 @@ import (
 	"github.com/dgraph-io/badger"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped/badgerwrap"
-	"github.com/stretchr/testify/assert"
 )
 
 func helper_KubeWatchResult_ShouldSkip() bool {


### PR DESCRIPTION
This combines the initial RangeRead with Key and Value predicates, with the new RangeRead that has keyPrefix.  Having one function will make testing easier, and this will let us slowly add the extra prefixKey parameter as needed to speed up queries that can use it.