### PR TITLE
Use gogen to get keyPredicateFn and valPredicteFn

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Jeffail/gabs/v2 v2.1.0
 	github.com/dgraph-io/badger v0.0.0-20190809121831-9d7b751e85c9
 	github.com/ghodss/yaml v1.0.0
-	github.com/gogo/protobuf v1.3.0 // indirect
+	github.com/gogo/protobuf v1.3.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.3.2
 	github.com/google/go-cmp v0.3.1 // indirect

--- a/pkg/sloop/queries/eventquery.go
+++ b/pkg/sloop/queries/eventquery.go
@@ -54,9 +54,8 @@ func GetEventData(params url.Values, t typed.Tables, startTime time.Time, endTim
 			Timestamp:   time.Time{},
 		}
 
-		// pass a few valPredFn filter: payload in time range and payload kind matched
-		//todo: use this practice for all other tables
-		valPredFn := NewCombinedValPredicate(isEventValInTimeRange(startTime, endTime), matchEventInvolvedObject(params))
+		// pass a few valPredFn filters: payload in time range and payload kind matched
+		valPredFn := typed.KubeWatchResult_ValPredicateFns(isEventValInTimeRange(startTime, endTime), matchEventInvolvedObject(params))
 		watchEvents, stats, err2 = t.WatchTable().RangeRead(txn, key, nil, valPredFn, startTime, endTime)
 		if err2 != nil {
 			return err2

--- a/pkg/sloop/queries/rangereadfilters.go
+++ b/pkg/sloop/queries/rangereadfilters.go
@@ -8,7 +8,6 @@
 package queries
 
 import (
-	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/salesforce/sloop/pkg/sloop/kubeextractor"
 	"github.com/salesforce/sloop/pkg/sloop/store/typed"
@@ -71,37 +70,6 @@ func paramFilterWatchActivityFn(params url.Values) func(string) bool {
 		name := k.Name
 		uuid := k.Uid
 		return keepRowHelper(name, kind, namespace, selectedKind, selectedNamespace, selectedNameSubstring, selectedNameExactMatch, selectedUuid, uuid)
-	}
-}
-
-func paramResPayloadFn(params url.Values) func(string) bool {
-	selectedNamespace := params.Get(NamespaceParam)
-	selectedName := params.Get(NameParam)
-	selectedKind := params.Get(KindParam)
-	if selectedKind == kubeextractor.NodeKind {
-		selectedNamespace = DefaultNamespace
-	}
-	return func(key string) bool {
-		k := &typed.WatchTableKey{}
-		err := k.Parse(key)
-
-		if err != nil {
-			glog.Errorf("Failed to parse key: %v", key)
-			return false
-		}
-
-		if k.Kind != selectedKind {
-			return false
-		}
-
-		if selectedNamespace != AllNamespaces && k.Namespace != selectedNamespace {
-			return false
-		}
-
-		if k.Name != selectedName {
-			return false
-		}
-		return true
 	}
 }
 
@@ -171,17 +139,6 @@ func isResSummaryValInTimeRange(startTime time.Time, endTime time.Time) func(*ty
 		}
 		if firstSeen.After(endTime) || lastSeen.Before(startTime) {
 			return false
-		}
-		return true
-	}
-}
-
-func NewCombinedValPredicate(valFn ...func(*typed.KubeWatchResult) bool) func(*typed.KubeWatchResult) bool {
-	return func(result *typed.KubeWatchResult) bool {
-		for _, thisFn := range valFn {
-			if !thisFn(result) {
-				return false
-			}
 		}
 		return true
 	}

--- a/pkg/sloop/queries/rangereadfilters_test.go
+++ b/pkg/sloop/queries/rangereadfilters_test.go
@@ -123,23 +123,6 @@ func Test_isEventValInTimeRange_True(t *testing.T) {
 	assert.True(t, flag)
 }
 
-func Test_paramEventDataFn_False(t *testing.T) {
-	values := helper_get_params()
-	key := "/watch/001562961600/Pod/someNS/someName.xx/1562963507608345756"
-	flag := paramResPayloadFn(values)(key)
-	assert.False(t, flag)
-}
-
-func Test_paramEventDataFn_True(t *testing.T) {
-	values := helper_get_params()
-	values[KindParam] = []string{kubeextractor.PodKind}
-	values[NamespaceParam] = []string{"someNS"}
-	values[NameParam] = []string{"someName"}
-	key := "/watch/001562961600/Pod/someNS/someName/1562963507608345756"
-	flag := paramResPayloadFn(values)(key)
-	assert.True(t, flag)
-}
-
 func Test_isResPayloadInTimeRange_True(t *testing.T) {
 	val := &typed.KubeWatchResult{Kind: "someKind", Timestamp: somePTime}
 	flag := isResPayloadInTimeRange(someTs.Add(-60*time.Minute), someTs.Add(60*time.Minute))(val)

--- a/pkg/sloop/store/typed/eventcounttablegen_test.go
+++ b/pkg/sloop/store/typed/eventcounttablegen_test.go
@@ -13,7 +13,6 @@ package typed
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 	"time"
@@ -21,6 +20,7 @@ import (
 	"github.com/dgraph-io/badger"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped/badgerwrap"
+	"github.com/stretchr/testify/assert"
 )
 
 func helper_ResourceEventCounts_ShouldSkip() bool {

--- a/pkg/sloop/store/typed/resourcesummarytablegen_test.go
+++ b/pkg/sloop/store/typed/resourcesummarytablegen_test.go
@@ -13,7 +13,6 @@ package typed
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 	"time"
@@ -21,6 +20,7 @@ import (
 	"github.com/dgraph-io/badger"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped/badgerwrap"
+	"github.com/stretchr/testify/assert"
 )
 
 func helper_ResourceSummary_ShouldSkip() bool {

--- a/pkg/sloop/store/typed/watchactivitytablegen_test.go
+++ b/pkg/sloop/store/typed/watchactivitytablegen_test.go
@@ -13,7 +13,6 @@ package typed
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 	"time"
@@ -21,6 +20,7 @@ import (
 	"github.com/dgraph-io/badger"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped/badgerwrap"
+	"github.com/stretchr/testify/assert"
 )
 
 func helper_WatchActivity_ShouldSkip() bool {

--- a/pkg/sloop/store/typed/watchtablegen.go
+++ b/pkg/sloop/store/typed/watchtablegen.go
@@ -207,7 +207,6 @@ func (t *KubeWatchResultTable) getLastMatchingKeyInPartition(txn badgerwrap.Txn,
 	return false, &WatchTableKey{}, nil
 }
 
-//todo: add unit tests
 func (t *KubeWatchResultTable) RangeRead(txn badgerwrap.Txn, keyPrefix *WatchTableKey,
 	keyPredicateFn func(string) bool, valPredicateFn func(*KubeWatchResult) bool, startTime time.Time, endTime time.Time) (map[WatchTableKey]*KubeWatchResult, RangeReadStats, error) {
 	resources := map[WatchTableKey]*KubeWatchResult{}
@@ -221,13 +220,12 @@ func (t *KubeWatchResultTable) RangeRead(txn badgerwrap.Txn, keyPrefix *WatchTab
 		return resources, stats, errors.Wrapf(err, "failed to get partitions from table:%v, from startTime:%v, to endTime:%v", t.tableName, startTime, endTime)
 	}
 
-	tablePrefix := "/" + t.tableName + "/"
 	for _, currentPartition := range partitionList {
 		var seekStr string
 
 		// when keyPrefix does not have such info as kind,namespace,and etc, we seek from /tableName/currentPartition/
 		if keyPrefix == nil {
-			seekStr = tablePrefix + currentPartition + "/"
+			seekStr = "/" + t.tableName + "/" + currentPartition + "/"
 		} else {
 			// update keyPrefix with current partition
 			keyPrefix.SetPartitionId(currentPartition)
@@ -296,4 +294,26 @@ func (t *KubeWatchResultTable) GetPartitionsFromTimeRange(txn badgerwrap.Txn, st
 		curPar = untyped.GetPartitionId(parTime)
 	}
 	return resources, nil
+}
+
+func KubeWatchResult_ValPredicateFns(valFn ...func(*KubeWatchResult) bool) func(*KubeWatchResult) bool {
+	return func(result *KubeWatchResult) bool {
+		for _, thisFn := range valFn {
+			if !thisFn(result) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+func KubeWatchResult_KeyPredicateFns(keyFn ...func(string) bool) func(string) bool {
+	return func(result string) bool {
+		for _, thisFn := range keyFn {
+			if !thisFn(result) {
+				return false
+			}
+		}
+		return true
+	}
 }

--- a/pkg/sloop/store/typed/watchtablegen_test.go
+++ b/pkg/sloop/store/typed/watchtablegen_test.go
@@ -13,7 +13,6 @@ package typed
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 	"time"
@@ -21,6 +20,7 @@ import (
 	"github.com/dgraph-io/badger"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped/badgerwrap"
+	"github.com/stretchr/testify/assert"
 )
 
 func helper_KubeWatchResult_ShouldSkip() bool {


### PR DESCRIPTION
Along our requirements for the rangeRead to grow, we want to have a way to pass more than one keyPredicateFn and valPredicteFn, we already used the similar approach in eventquery.go  where reangeRead to valPredicteFn for both payload's time check and payload's kind check.

This PR is trying use gogen to create same function for all tables.