### PR TITLE
fix the partition for keyComparator

### DIFF
--- a/pkg/sloop/store/typed/tabletemplate.go
+++ b/pkg/sloop/store/typed/tabletemplate.go
@@ -153,7 +153,7 @@ func (t *ValueTypeTable) GetUniquePartitionList(txn badgerwrap.Txn) ([]string, e
 }
 
 //todo: need to add unit test
-func (t *ValueTypeTable) GetPreviousKey(txn badgerwrap.Txn, key *KeyType, keyPrefix *KeyType) (*KeyType, error) {
+func (t *ValueTypeTable) GetPreviousKey(txn badgerwrap.Txn, key *KeyType, keyComparator *KeyType) (*KeyType, error) {
 	partitionList, err := t.GetUniquePartitionList(txn)
 	if err != nil {
 		return &KeyType{}, errors.Wrapf(err, "failed to get partition list from table:%v", t.tableName)
@@ -164,7 +164,7 @@ func (t *ValueTypeTable) GetPreviousKey(txn badgerwrap.Txn, key *KeyType, keyPre
 		if prePart > currentPartition {
 			continue
 		} else {
-			prevFound, prevKey, err := t.getLastMatchingKeyInPartition(txn, prePart, key, keyPrefix)
+			prevFound, prevKey, err := t.getLastMatchingKeyInPartition(txn, prePart, key, keyComparator)
 			if err != nil {
 				return &KeyType{}, errors.Wrapf(err, "Failure getting previous key for %v, for partition id:%v", key.String(), prePart)
 			}
@@ -173,11 +173,11 @@ func (t *ValueTypeTable) GetPreviousKey(txn badgerwrap.Txn, key *KeyType, keyPre
 			}
 		}
 	}
-	return &KeyType{}, fmt.Errorf("failed to get any previous key in table:%v, for key:%v, keyPrefix:%v", t.tableName, key.String(), keyPrefix)
+	return &KeyType{}, fmt.Errorf("failed to get any previous key in table:%v, for key:%v, keyComparator:%v", t.tableName, key.String(), keyComparator)
 }
 
 //todo: need to add unit test
-func (t *ValueTypeTable) getLastMatchingKeyInPartition(txn badgerwrap.Txn, curPartition string, curKey *KeyType, keyPrefix *KeyType) (bool, *KeyType, error) {
+func (t *ValueTypeTable) getLastMatchingKeyInPartition(txn badgerwrap.Txn, curPartition string, curKey *KeyType, keyComparator *KeyType) (bool, *KeyType, error) {
 	iterOpt := badger.DefaultIteratorOptions
 	iterOpt.Reverse = true
 	itr := txn.NewIterator(iterOpt)
@@ -187,8 +187,9 @@ func (t *ValueTypeTable) getLastMatchingKeyInPartition(txn badgerwrap.Txn, curPa
 
 	// update partition with current value
 	curKey.SetPartitionId(curPartition)
-	keySeekStr := curKey.String() + string(rune(255))
+	keyComparator.SetPartitionId(curPartition)
 
+	keySeekStr := curKey.String() + string(rune(255))
 	itr.Seek([]byte(keySeekStr))
 
 	// if the result is same as key, we want to check its previous one
@@ -196,7 +197,7 @@ func (t *ValueTypeTable) getLastMatchingKeyInPartition(txn badgerwrap.Txn, curPa
 		itr.Next()
 	}
 
-	if itr.ValidForPrefix([]byte(keyPrefix.String())) {
+	if itr.ValidForPrefix([]byte(keyComparator.String())) {
 		key := &KeyType{}
 		err := key.Parse(string(itr.Item().Key()))
 		if err != nil {

--- a/pkg/sloop/store/typed/watchactivitytablegen.go
+++ b/pkg/sloop/store/typed/watchactivitytablegen.go
@@ -153,7 +153,7 @@ func (t *WatchActivityTable) GetUniquePartitionList(txn badgerwrap.Txn) ([]strin
 }
 
 //todo: need to add unit test
-func (t *WatchActivityTable) GetPreviousKey(txn badgerwrap.Txn, key *WatchActivityKey, keyPrefix *WatchActivityKey) (*WatchActivityKey, error) {
+func (t *WatchActivityTable) GetPreviousKey(txn badgerwrap.Txn, key *WatchActivityKey, keyComparator *WatchActivityKey) (*WatchActivityKey, error) {
 	partitionList, err := t.GetUniquePartitionList(txn)
 	if err != nil {
 		return &WatchActivityKey{}, errors.Wrapf(err, "failed to get partition list from table:%v", t.tableName)
@@ -164,7 +164,7 @@ func (t *WatchActivityTable) GetPreviousKey(txn badgerwrap.Txn, key *WatchActivi
 		if prePart > currentPartition {
 			continue
 		} else {
-			prevFound, prevKey, err := t.getLastMatchingKeyInPartition(txn, prePart, key, keyPrefix)
+			prevFound, prevKey, err := t.getLastMatchingKeyInPartition(txn, prePart, key, keyComparator)
 			if err != nil {
 				return &WatchActivityKey{}, errors.Wrapf(err, "Failure getting previous key for %v, for partition id:%v", key.String(), prePart)
 			}
@@ -173,11 +173,11 @@ func (t *WatchActivityTable) GetPreviousKey(txn badgerwrap.Txn, key *WatchActivi
 			}
 		}
 	}
-	return &WatchActivityKey{}, fmt.Errorf("failed to get any previous key in table:%v, for key:%v, keyPrefix:%v", t.tableName, key.String(), keyPrefix)
+	return &WatchActivityKey{}, fmt.Errorf("failed to get any previous key in table:%v, for key:%v, keyComparator:%v", t.tableName, key.String(), keyComparator)
 }
 
 //todo: need to add unit test
-func (t *WatchActivityTable) getLastMatchingKeyInPartition(txn badgerwrap.Txn, curPartition string, curKey *WatchActivityKey, keyPrefix *WatchActivityKey) (bool, *WatchActivityKey, error) {
+func (t *WatchActivityTable) getLastMatchingKeyInPartition(txn badgerwrap.Txn, curPartition string, curKey *WatchActivityKey, keyComparator *WatchActivityKey) (bool, *WatchActivityKey, error) {
 	iterOpt := badger.DefaultIteratorOptions
 	iterOpt.Reverse = true
 	itr := txn.NewIterator(iterOpt)
@@ -187,8 +187,9 @@ func (t *WatchActivityTable) getLastMatchingKeyInPartition(txn badgerwrap.Txn, c
 
 	// update partition with current value
 	curKey.SetPartitionId(curPartition)
-	keySeekStr := curKey.String() + string(rune(255))
+	keyComparator.SetPartitionId(curPartition)
 
+	keySeekStr := curKey.String() + string(rune(255))
 	itr.Seek([]byte(keySeekStr))
 
 	// if the result is same as key, we want to check its previous one
@@ -196,7 +197,7 @@ func (t *WatchActivityTable) getLastMatchingKeyInPartition(txn badgerwrap.Txn, c
 		itr.Next()
 	}
 
-	if itr.ValidForPrefix([]byte(keyPrefix.String())) {
+	if itr.ValidForPrefix([]byte(keyComparator.String())) {
 		key := &WatchActivityKey{}
 		err := key.Parse(string(itr.Item().Key()))
 		if err != nil {

--- a/pkg/sloop/store/typed/watchtablegen.go
+++ b/pkg/sloop/store/typed/watchtablegen.go
@@ -153,7 +153,7 @@ func (t *KubeWatchResultTable) GetUniquePartitionList(txn badgerwrap.Txn) ([]str
 }
 
 //todo: need to add unit test
-func (t *KubeWatchResultTable) GetPreviousKey(txn badgerwrap.Txn, key *WatchTableKey, keyPrefix *WatchTableKey) (*WatchTableKey, error) {
+func (t *KubeWatchResultTable) GetPreviousKey(txn badgerwrap.Txn, key *WatchTableKey, keyComparator *WatchTableKey) (*WatchTableKey, error) {
 	partitionList, err := t.GetUniquePartitionList(txn)
 	if err != nil {
 		return &WatchTableKey{}, errors.Wrapf(err, "failed to get partition list from table:%v", t.tableName)
@@ -164,7 +164,7 @@ func (t *KubeWatchResultTable) GetPreviousKey(txn badgerwrap.Txn, key *WatchTabl
 		if prePart > currentPartition {
 			continue
 		} else {
-			prevFound, prevKey, err := t.getLastMatchingKeyInPartition(txn, prePart, key, keyPrefix)
+			prevFound, prevKey, err := t.getLastMatchingKeyInPartition(txn, prePart, key, keyComparator)
 			if err != nil {
 				return &WatchTableKey{}, errors.Wrapf(err, "Failure getting previous key for %v, for partition id:%v", key.String(), prePart)
 			}
@@ -173,11 +173,11 @@ func (t *KubeWatchResultTable) GetPreviousKey(txn badgerwrap.Txn, key *WatchTabl
 			}
 		}
 	}
-	return &WatchTableKey{}, fmt.Errorf("failed to get any previous key in table:%v, for key:%v, keyPrefix:%v", t.tableName, key.String(), keyPrefix)
+	return &WatchTableKey{}, fmt.Errorf("failed to get any previous key in table:%v, for key:%v, keyComparator:%v", t.tableName, key.String(), keyComparator)
 }
 
 //todo: need to add unit test
-func (t *KubeWatchResultTable) getLastMatchingKeyInPartition(txn badgerwrap.Txn, curPartition string, curKey *WatchTableKey, keyPrefix *WatchTableKey) (bool, *WatchTableKey, error) {
+func (t *KubeWatchResultTable) getLastMatchingKeyInPartition(txn badgerwrap.Txn, curPartition string, curKey *WatchTableKey, keyComparator *WatchTableKey) (bool, *WatchTableKey, error) {
 	iterOpt := badger.DefaultIteratorOptions
 	iterOpt.Reverse = true
 	itr := txn.NewIterator(iterOpt)
@@ -187,8 +187,9 @@ func (t *KubeWatchResultTable) getLastMatchingKeyInPartition(txn badgerwrap.Txn,
 
 	// update partition with current value
 	curKey.SetPartitionId(curPartition)
-	keySeekStr := curKey.String() + string(rune(255))
+	keyComparator.SetPartitionId(curPartition)
 
+	keySeekStr := curKey.String() + string(rune(255))
 	itr.Seek([]byte(keySeekStr))
 
 	// if the result is same as key, we want to check its previous one
@@ -196,7 +197,7 @@ func (t *KubeWatchResultTable) getLastMatchingKeyInPartition(txn badgerwrap.Txn,
 		itr.Next()
 	}
 
-	if itr.ValidForPrefix([]byte(keyPrefix.String())) {
+	if itr.ValidForPrefix([]byte(keyComparator.String())) {
 		key := &WatchTableKey{}
 		err := key.Parse(string(itr.Item().Key()))
 		if err != nil {


### PR DESCRIPTION
This PR is trying to fix 2 things:
1. rename keyPrefix to keyComparator to reduce misunderstanding
2. update the keyComparator with currentPartition so even when there is no partition info in keyComparator, we can still getPreviousKey.