### PR TITLE
Fix the binary path in the helm statefulset

### DIFF
--- a/helm/sloop/templates/clusterrole.yaml
+++ b/helm/sloop/templates/clusterrole.yaml
@@ -96,8 +96,9 @@ rules:
     verbs:
       - list
       - watch
- # CRDs that you want to watch need to be added here
- # Istio added as an example
+# List CRDs that you want to watch here
+# Istio is just here as an example.  Alternatively if you want to get all CRDs its possible to add '*'
+# to apiGroups, but that would give sloop permissions to read secrets which may not be desirable
   - apiGroups:
       - authentication.istio.io
       - config.istio.io

--- a/helm/sloop/templates/clusterrole.yaml
+++ b/helm/sloop/templates/clusterrole.yaml
@@ -89,3 +89,23 @@ rules:
     verbs: 
       - list
       - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+      - watch
+ # CRDs that you want to watch need to be added here
+ # Istio added as an example
+  - apiGroups:
+      - authentication.istio.io
+      - config.istio.io
+      - networking.istio.io
+      - rbac.istio.io
+      - security.istio.io
+    resources:
+      - '*'
+    verbs:
+      - list
+      - watch

--- a/helm/sloop/templates/statefulset.yaml
+++ b/helm/sloop/templates/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
       - args:
         - --config=/sloopconfig/sloop.json
         command:
-        - /bin/sloop
+        - /sloop
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         name: sloop
         ports:


### PR DESCRIPTION
The recent change to the Dockerfile moved the sloop binary from /bin to / and add CRD list to clusterrole