### PR TITLE
fix the misplacement of code caused by go gen

### DIFF
--- a/pkg/sloop/store/typed/eventcounttable_test.go
+++ b/pkg/sloop/store/typed/eventcounttable_test.go
@@ -9,6 +9,7 @@ package typed
 
 import (
 	"github.com/dgraph-io/badger"
+	"github.com/salesforce/sloop/pkg/sloop/kubeextractor"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped/badgerwrap"
 	"github.com/salesforce/sloop/pkg/sloop/test/assertex"
@@ -195,4 +196,82 @@ func (*EventCountKey) SetTestKeys() []string {
 
 func (*EventCountKey) SetTestValue() *ResourceEventCounts {
 	return &ResourceEventCounts{}
+}
+
+func helper_testKeys() []string {
+	return []string{
+		// someMaxTs partition
+		"/eventcount/001546405200/Pod/user-j/sync-123/sam-partition-testdata",
+		"/eventcount/001546405200/Pod/user-j/sync-123/sam-partition-test",
+
+		"/eventcount/001546405200/somekind/somenamespace/somename/previous-partition-test",
+		"/eventcount/001546405200/user-a/somenamespace/somename/478-aaa",
+		"/eventcount/001546405200/user-b/somenamespace/somename/477-bbb",
+		"/eventcount/001546405200/somekind/somenamespacetest/somename/skipped-partition",
+
+		// someMiddleTs partition
+		"/eventcount/001546401600/somekind/somenamespace/somename/previous-partition-test",
+		"/eventcount/001546401600/somekind/somenamespace/somename/cde-4ffc-11e9-8e26-123",
+
+		// someTs partition
+		"/eventcount/001546398000/somekind/somenamespace/somename/previous-partition-test",
+		"/eventcount/001546398000/somekind123/somenamespace/somename/68510937-4ffc-11e9-8e26-123",
+		"/eventcount/001546398000/somekind/somenamespacetest/somename/skipped-partition",
+
+		"/eventcount/001546398000/somekindaaa/somenamespaceaaa/somenameaaa/aaaa",
+	}
+}
+
+func Test_EventCount_GetPreviousKey_Success(t *testing.T) {
+	untyped.TestHookSetPartitionDuration(time.Hour)
+	db, wt := helper_update_ResourceEventCountsTable(t, helper_testKeys(), (&EventCountKey{}).SetTestValue())
+	var partRes *EventCountKey
+	var err1 error
+
+	// testing in the same partition
+	curKey := NewEventCountKey(someMaxTs, kubeextractor.PodKind, "user-j", "sync-123", "sam-partition-testdata")
+	keyComparator := NewEventCountKeyComparator(kubeextractor.PodKind, "user-j", "sync-123", "")
+	err := db.View(func(txn badgerwrap.Txn) error {
+		partRes, err1 = wt.GetPreviousKey(txn, curKey, keyComparator)
+		return err1
+	})
+	assert.Nil(t, err)
+	expectedKey := NewEventCountKey(someMaxTs, kubeextractor.PodKind, "user-j", "sync-123", "sam-partition-test")
+	assert.Equal(t, expectedKey, partRes)
+
+	// testing in the previous partition
+	curKey = NewEventCountKey(someMaxTs, someKind, someNamespace, someName, "previous-partition-test")
+	keyComparator = NewEventCountKeyComparator(someKind, someNamespace, someName, "previous-partition-test")
+	err = db.View(func(txn badgerwrap.Txn) error {
+		partRes, err1 = wt.GetPreviousKey(txn, curKey, keyComparator)
+		return err1
+	})
+	assert.Nil(t, err)
+	expectedKey = NewEventCountKey(someMiddleTs, someKind, someNamespace, someName, "previous-partition-test")
+	assert.Equal(t, expectedKey, partRes)
+
+	// testing in skipped partition
+	curKey = NewEventCountKey(someMaxTs, someKind, "somenamespacetest", someName, "skipped-partition")
+	keyComparator = NewEventCountKeyComparator(someKind, "somenamespacetest", someName, "skipped-partition")
+	err = db.View(func(txn badgerwrap.Txn) error {
+		partRes, err1 = wt.GetPreviousKey(txn, curKey, keyComparator)
+		return err1
+	})
+	assert.Nil(t, err)
+	expectedKey = NewEventCountKey(someTs, someKind, "somenamespacetest", someName, "skipped-partition")
+	assert.Equal(t, expectedKey, partRes)
+}
+
+func Test_EventCount_GetPreviousKey_Fail(t *testing.T) {
+	db, wt := helper_update_ResourceEventCountsTable(t, (&EventCountKey{}).SetTestKeys(), (&EventCountKey{}).SetTestValue())
+	var partRes *EventCountKey
+	var err1 error
+	curKey := NewEventCountKey(someMaxTs, someKind, someNamespace, someName, someUid)
+	keyComparator := NewEventCountKeyComparator(someKind+"b", someNamespace, someName, someUid)
+	err := db.View(func(txn badgerwrap.Txn) error {
+		partRes, err1 = wt.GetPreviousKey(txn, curKey, keyComparator)
+		return err1
+	})
+	assert.NotNil(t, err)
+	assert.Equal(t, &EventCountKey{}, partRes)
 }

--- a/pkg/sloop/store/typed/eventcounttablegen.go
+++ b/pkg/sloop/store/typed/eventcounttablegen.go
@@ -190,7 +190,7 @@ func (t *ResourceEventCountsTable) getLastMatchingKeyInPartition(txn badgerwrap.
 	itr.Seek([]byte(keySeekStr))
 
 	// if the result is same as key, we want to check its previous one
-	if oldKey == string(itr.Item().Key()) {
+	if itr.Valid() && oldKey == string(itr.Item().Key()) {
 		itr.Next()
 	}
 

--- a/pkg/sloop/store/typed/resourcesummarytablegen.go
+++ b/pkg/sloop/store/typed/resourcesummarytablegen.go
@@ -190,7 +190,7 @@ func (t *ResourceSummaryTable) getLastMatchingKeyInPartition(txn badgerwrap.Txn,
 	itr.Seek([]byte(keySeekStr))
 
 	// if the result is same as key, we want to check its previous one
-	if oldKey == string(itr.Item().Key()) {
+	if itr.Valid() && oldKey == string(itr.Item().Key()) {
 		itr.Next()
 	}
 

--- a/pkg/sloop/store/typed/resourcesummarytablegen_test.go
+++ b/pkg/sloop/store/typed/resourcesummarytablegen_test.go
@@ -112,32 +112,3 @@ func Test_ResourceSummaryTable_GetUniquePartitionList_EmptyPartition(t *testing.
 	assert.Nil(t, err)
 	assert.Len(t, partList, 0)
 }
-
-func Test_ResourceSummary_GetPreviousKey_Success(t *testing.T) {
-	db, wt := helper_update_ResourceSummaryTable(t, (&ResourceSummaryKey{}).SetTestKeys(), (&ResourceSummaryKey{}).SetTestValue())
-	var partRes *ResourceSummaryKey
-	var err1 error
-	curKey := NewResourceSummaryKey(someMaxTs, someKind, someNamespace, someName, someUid+"c")
-	keyComparator := NewResourceSummaryKeyComparator(someKind, someNamespace, someName, someUid+"b")
-	err := db.View(func(txn badgerwrap.Txn) error {
-		partRes, err1 = wt.GetPreviousKey(txn, curKey, keyComparator)
-		return err1
-	})
-	assert.Nil(t, err)
-	expectedKey := NewResourceSummaryKey(someTs.Add(1*time.Hour), someKind, someNamespace, someName, someUid+"b")
-	assert.Equal(t, expectedKey, partRes)
-}
-
-func Test_ResourceSummary_GetPreviousKey_Fail(t *testing.T) {
-	db, wt := helper_update_ResourceSummaryTable(t, (&ResourceSummaryKey{}).SetTestKeys(), (&ResourceSummaryKey{}).SetTestValue())
-	var partRes *ResourceSummaryKey
-	var err1 error
-	curKey := NewResourceSummaryKey(someTs.Add(2*time.Hour), someKind, someNamespace, someName, someUid)
-	keyComparator := NewResourceSummaryKeyComparator(someKind+"b", someNamespace, someName, someUid)
-	err := db.View(func(txn badgerwrap.Txn) error {
-		partRes, err1 = wt.GetPreviousKey(txn, curKey, keyComparator)
-		return err1
-	})
-	assert.NotNil(t, err)
-	assert.Equal(t, &ResourceSummaryKey{}, partRes)
-}

--- a/pkg/sloop/store/typed/tabletemplate.go
+++ b/pkg/sloop/store/typed/tabletemplate.go
@@ -190,7 +190,7 @@ func (t *ValueTypeTable) getLastMatchingKeyInPartition(txn badgerwrap.Txn, curPa
 	itr.Seek([]byte(keySeekStr))
 
 	// if the result is same as key, we want to check its previous one
-	if oldKey == string(itr.Item().Key()) {
+	if itr.Valid() && oldKey == string(itr.Item().Key()) {
 		itr.Next()
 	}
 

--- a/pkg/sloop/store/typed/watchactivitytable_test.go
+++ b/pkg/sloop/store/typed/watchactivitytable_test.go
@@ -155,6 +155,35 @@ func Test_WatchActivity_getLastMatchingKeyInPartition_NotFound(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func Test_WatchActivity_GetPreviousKey_Success(t *testing.T) {
+	db, wt := helper_update_WatchActivityTable(t, (&WatchActivityKey{}).SetTestKeys(), (&WatchActivityKey{}).GetTestValue())
+	var partRes *WatchActivityKey
+	var err1 error
+	curKey := NewWatchActivityKey(someMaxPartition, someKind, someNamespace, someName, someUid+"c")
+	keyComarator := NewWatchActivityKeyComparator(someKind, someNamespace, someName, someUid)
+	err := db.View(func(txn badgerwrap.Txn) error {
+		partRes, err1 = wt.GetPreviousKey(txn, curKey, keyComarator)
+		return err1
+	})
+	assert.Nil(t, err)
+	expectedKey := NewWatchActivityKey(someMaxPartition, someKind, someNamespace, someName, someUid)
+	assert.Equal(t, expectedKey, partRes)
+}
+
+func Test_WatchActivity_GetPreviousKey_Fail(t *testing.T) {
+	db, wt := helper_update_WatchActivityTable(t, (&WatchActivityKey{}).SetTestKeys(), (&WatchActivityKey{}).GetTestValue())
+	var partRes *WatchActivityKey
+	var err1 error
+	curKey := NewWatchActivityKey(someMaxPartition, someKind, someNamespace, someName, someUid)
+	keyComarator := NewWatchActivityKeyComparator(someKind+"a", someNamespace, someName, someUid)
+	err := db.View(func(txn badgerwrap.Txn) error {
+		partRes, err1 = wt.GetPreviousKey(txn, curKey, keyComarator)
+		return err1
+	})
+	assert.NotNil(t, err)
+	assert.Equal(t, &WatchActivityKey{}, partRes)
+}
+
 func (*WatchActivityKey) GetTestKey() string {
 	k := NewWatchActivityKey(someMinPartition, someKind, someNamespace, someName, someUid)
 	return k.String()

--- a/pkg/sloop/store/typed/watchactivitytablegen.go
+++ b/pkg/sloop/store/typed/watchactivitytablegen.go
@@ -190,7 +190,7 @@ func (t *WatchActivityTable) getLastMatchingKeyInPartition(txn badgerwrap.Txn, c
 	itr.Seek([]byte(keySeekStr))
 
 	// if the result is same as key, we want to check its previous one
-	if oldKey == string(itr.Item().Key()) {
+	if itr.Valid() && oldKey == string(itr.Item().Key()) {
 		itr.Next()
 	}
 

--- a/pkg/sloop/store/typed/watchactivitytablegen_test.go
+++ b/pkg/sloop/store/typed/watchactivitytablegen_test.go
@@ -51,7 +51,6 @@ func Test_WatchActivityTable_SetWorks(t *testing.T) {
 }
 
 func helper_update_WatchActivityTable(t *testing.T, keys []string, val *WatchActivity) (badgerwrap.DB, *WatchActivityTable) {
-	untyped.TestHookSetPartitionDuration(time.Hour)
 	b, err := (&badgerwrap.MockFactory{}).Open(badger.DefaultOptions(""))
 	assert.Nil(t, err)
 	wt := OpenWatchActivityTable()
@@ -112,33 +111,4 @@ func Test_WatchActivityTable_GetUniquePartitionList_EmptyPartition(t *testing.T)
 	})
 	assert.Nil(t, err)
 	assert.Len(t, partList, 0)
-}
-
-func Test_WatchActivity_GetPreviousKey_Success(t *testing.T) {
-	db, wt := helper_update_WatchActivityTable(t, (&WatchActivityKey{}).SetTestKeys(), (&WatchActivityKey{}).GetTestValue())
-	var partRes *WatchActivityKey
-	var err1 error
-	curKey := NewWatchActivityKey(someMaxPartition, someKind, someNamespace, someName, someUid+"c")
-	keyComarator := NewWatchActivityKeyComparator(someKind, someNamespace, someName, someUid)
-	err := db.View(func(txn badgerwrap.Txn) error {
-		partRes, err1 = wt.GetPreviousKey(txn, curKey, keyComarator)
-		return err1
-	})
-	assert.Nil(t, err)
-	expectedKey := NewWatchActivityKey(someMaxPartition, someKind, someNamespace, someName, someUid)
-	assert.Equal(t, expectedKey, partRes)
-}
-
-func Test_WatchActivity_GetPreviousKey_Fail(t *testing.T) {
-	db, wt := helper_update_WatchActivityTable(t, (&WatchActivityKey{}).SetTestKeys(), (&WatchActivityKey{}).GetTestValue())
-	var partRes *WatchActivityKey
-	var err1 error
-	curKey := NewWatchActivityKey(someMaxPartition, someKind, someNamespace, someName, someUid)
-	keyComarator := NewWatchActivityKeyComparator(someKind+"a", someNamespace, someName, someUid)
-	err := db.View(func(txn badgerwrap.Txn) error {
-		partRes, err1 = wt.GetPreviousKey(txn, curKey, keyComarator)
-		return err1
-	})
-	assert.NotNil(t, err)
-	assert.Equal(t, &WatchActivityKey{}, partRes)
 }

--- a/pkg/sloop/store/typed/watchtablegen.go
+++ b/pkg/sloop/store/typed/watchtablegen.go
@@ -157,7 +157,6 @@ func (t *KubeWatchResultTable) GetPreviousKey(txn badgerwrap.Txn, key *WatchTabl
 		return &WatchTableKey{}, errors.Wrapf(err, "failed to get partition list from table:%v", t.tableName)
 	}
 	currentPartition := key.PartitionId
-
 	for i := len(partitionList) - 1; i >= 0; i-- {
 		prePart := partitionList[i]
 		if prePart > currentPartition {

--- a/pkg/sloop/store/typed/watchtablegen_test.go
+++ b/pkg/sloop/store/typed/watchtablegen_test.go
@@ -112,32 +112,3 @@ func Test_KubeWatchResultTable_GetUniquePartitionList_EmptyPartition(t *testing.
 	assert.Nil(t, err)
 	assert.Len(t, partList, 0)
 }
-
-func Test_GetPreviousKey_Success(t *testing.T) {
-	db, wt := helper_update_KubeWatchResultTable(t, (&WatchTableKey{}).SetTestKeys(), (&WatchTableKey{}).SetTestValue())
-	var partRes *WatchTableKey
-	var err1 error
-	curKey := NewWatchTableKey(someMaxPartition, someKind, someNamespace, someName, someTs)
-	keyComparator := NewWatchTableKeyComparator(someKind, someNamespace, someName, zeroData)
-	err := db.View(func(txn badgerwrap.Txn) error {
-		partRes, err1 = wt.GetPreviousKey(txn, curKey, keyComparator)
-		return err1
-	})
-	assert.Nil(t, err)
-	expectedKey := NewWatchTableKey(someMaxPartition, someKind, someNamespace, someName, someTs.Add(time.Hour*-5))
-	assert.Equal(t, expectedKey, partRes)
-}
-
-func Test_GetPreviousKey_Fail(t *testing.T) {
-	db, wt := helper_update_KubeWatchResultTable(t, (&WatchTableKey{}).SetTestKeys(), (&WatchTableKey{}).SetTestValue())
-	var partRes *WatchTableKey
-	var err1 error
-	curKey := NewWatchTableKey(someMaxPartition, someKind, someNamespace, someName, someTs)
-	keyComparator := NewWatchTableKeyComparator(someKind+"c", someNamespace, someName, zeroData)
-	err := db.View(func(txn badgerwrap.Txn) error {
-		partRes, err1 = wt.GetPreviousKey(txn, curKey, keyComparator)
-		return err1
-	})
-	assert.NotNil(t, err)
-	assert.Equal(t, &WatchTableKey{}, partRes)
-}


### PR DESCRIPTION
This PR is trying to do 2 things:
1. add itr.Valid() check for corner cases
2. move the code from gen to the right place, othrewise every time when run `make generate` some of the functions will be deleted.