### PR TITLE
Data Backup Endpoint

### DIFF
--- a/pkg/sloop/server/server.go
+++ b/pkg/sloop/server/server.go
@@ -9,23 +9,26 @@ package server
 
 import (
 	"flag"
+	"os"
+	"path"
+	"strings"
+	"time"
+
 	"github.com/pkg/errors"
+
 	"github.com/salesforce/sloop/pkg/sloop/ingress"
 	"github.com/salesforce/sloop/pkg/sloop/server/internal/config"
 	"github.com/salesforce/sloop/pkg/sloop/store/typed"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped"
-	"os"
-	"path"
-	"strings"
 
 	"github.com/golang/glog"
+
+	"github.com/spf13/afero"
 
 	"github.com/salesforce/sloop/pkg/sloop/processing"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped/badgerwrap"
 	"github.com/salesforce/sloop/pkg/sloop/storemanager"
 	"github.com/salesforce/sloop/pkg/sloop/webserver"
-	"github.com/spf13/afero"
-	"time"
 )
 
 const alsologtostderr = "alsologtostderr"
@@ -111,7 +114,7 @@ func RealMain() error {
 		LeftBarLinks:     conf.LeftBarLinks,
 		CurrentContext:   displayContext,
 	}
-	err = webserver.Run(webConfig, tables)
+	err = webserver.Run(webConfig, tables, db)
 	if err != nil {
 		return errors.Wrap(err, "failed to run webserver")
 	}

--- a/pkg/sloop/server/server.go
+++ b/pkg/sloop/server/server.go
@@ -114,7 +114,7 @@ func RealMain() error {
 		LeftBarLinks:     conf.LeftBarLinks,
 		CurrentContext:   displayContext,
 	}
-	err = webserver.Run(webConfig, tables, db)
+	err = webserver.Run(webConfig, tables)
 	if err != nil {
 		return errors.Wrap(err, "failed to run webserver")
 	}

--- a/pkg/sloop/store/untyped/badgerwrap/api.go
+++ b/pkg/sloop/store/untyped/badgerwrap/api.go
@@ -8,6 +8,8 @@
 package badgerwrap
 
 import (
+	"io"
+
 	"github.com/dgraph-io/badger"
 )
 
@@ -25,7 +27,7 @@ type DB interface {
 	DropPrefix(prefix []byte) error
 	Size() (lsm, vlog int64)
 	Tables(withKeysCount bool) []badger.TableInfo
-	//	Backup(w io.Writer, since uint64) (uint64, error)
+	Backup(w io.Writer, since uint64) (uint64, error)
 	//	DropAll() error
 	//	Flatten(workers int) error
 	//	GetMergeOperator(key []byte, f MergeFunc, dur time.Duration) *MergeOperator

--- a/pkg/sloop/store/untyped/badgerwrap/badger.go
+++ b/pkg/sloop/store/untyped/badgerwrap/badger.go
@@ -8,6 +8,8 @@
 package badgerwrap
 
 import (
+	"io"
+
 	"github.com/dgraph-io/badger"
 	"github.com/pkg/errors"
 )
@@ -72,6 +74,10 @@ func (b *BadgerDb) Size() (lsm, vlog int64) {
 
 func (b *BadgerDb) Tables(withKeysCount bool) []badger.TableInfo {
 	return b.db.Tables(withKeysCount)
+}
+
+func (b *BadgerDb) Backup(w io.Writer, since uint64) (uint64, error) {
+	return b.db.Backup(w, since)
 }
 
 // Transaction

--- a/pkg/sloop/store/untyped/badgerwrap/mock.go
+++ b/pkg/sloop/store/untyped/badgerwrap/mock.go
@@ -9,10 +9,12 @@ package badgerwrap
 
 import (
 	"fmt"
-	"github.com/dgraph-io/badger"
+	"io"
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/dgraph-io/badger"
 )
 
 // This mock simulates badger using an in-memory store
@@ -106,6 +108,10 @@ func (b *MockDb) Tables(withKeysCount bool) []badger.TableInfo {
 	return []badger.TableInfo{
 		{KeyCount: uint64(keyCount)},
 	}
+}
+
+func (b *MockDb) Backup(w io.Writer, since uint64) (uint64, error) {
+	return 0, nil
 }
 
 // Transaction

--- a/pkg/sloop/webserver/webserver.go
+++ b/pkg/sloop/webserver/webserver.go
@@ -114,7 +114,7 @@ func backupHandler(db badgerwrap.DB, currentContext string) http.HandlerFunc {
 		}
 		since, err := strconv.ParseUint(sinceStr, 10, 64)
 		if err != nil {
-			logWebError(err, "Error parsing 'since': "+sinceStr, r, w)
+			logWebError(err, "Error parsing 'since' parameter. Must be expressed as a positive integer.", r, w)
 			return
 		}
 

--- a/pkg/sloop/webserver/webserver.go
+++ b/pkg/sloop/webserver/webserver.go
@@ -156,12 +156,12 @@ func healthHandler() http.HandlerFunc {
 	}
 }
 
-func Run(config WebConfig, tables typed.Tables, db badgerwrap.DB) error {
+func Run(config WebConfig, tables typed.Tables) error {
 	webFiles = config.WebFilesPath
 	server := &Server{}
 	server.mux = http.NewServeMux()
 	server.mux.HandleFunc("/webfiles/", webFileHandler)
-	server.mux.HandleFunc("/data/backup", backupHandler(db, config.CurrentContext))
+	server.mux.HandleFunc("/data/backup", backupHandler(tables.Db(), config.CurrentContext))
 	server.mux.HandleFunc("/data", queryHandler(tables, config.MaxLookback))
 	server.mux.HandleFunc("/resource", resourceHandler(config.ResourceLinks))
 	server.mux.HandleFunc("/debug/", listKeysHandler(tables))

--- a/pkg/sloop/webserver/webserver.go
+++ b/pkg/sloop/webserver/webserver.go
@@ -103,6 +103,9 @@ func webFileHandler(w http.ResponseWriter, r *http.Request) {
 	glog.V(2).Infof("webFileHandler successfully returned file %v for %v", fixedUrl, r.URL)
 }
 
+// backupHandler streams a download of a backup of the database.
+// It is a simple HTTP translation of the Badger DB's built-in online backup function.
+// If the optional `since` query parameter is provided, the backup will only include versions since the version provided.
 func backupHandler(db badgerwrap.DB, currentContext string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		sinceStr := r.URL.Query().Get("since")


### PR DESCRIPTION
## Description

This adds an endpoint to download a backup of the Badger DB. This is a simple HTTP translation of the built-in [online backup](https://github.com/dgraph-io/badger#database-backup) function. It takes an optional `since` param and returns a streaming download of the backup.

## Use Case

This can surely have many different use cases, but for us, we run ephemeral clusters for testing and need to be able to dump out the contents of Sloop before the cluster is torn down.

## Demo

### Download Backup

*This is the actual feature added. Shown here with `curl`, but also works in browser; however, I didn't actually add a link to the page since it's probably not something you'd want to have most users casually accessing. Note the use of `-OJ` flags which read the `Content-Disposition` header to get the filename like a browser does.*

```
$ curl -OJ http://localhost:8080/data/backup                                                       
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  212M    0  212M    0     0   228M      0 --:--:-- --:--:-- --:--:--  228M
curl: Saved to filename 'sloop-brainard-l-1-restored-0.bak'
```

### Restore from Backup

*Shown just to demonstrate that the backup actually works. Note, you must use a version of the `badger` CLI that is version compatible. I did this by installing from the go mod cache at the same version hash. In the future, I may send a PR to make allow starting directly from a backup using `DB.Load()` to make this step unnessisary.*

```
$ badger restore --backup-file sloop-brainard-l-1-restored-0.bak --dir /tmp/sloop-restore/brainard-l-1
Listening for /debug HTTP requests at port: 8080
badger 2019/11/12 23:18:16 INFO: All 0 tables opened in 0s
badger 2019/11/12 23:18:17 DEBUG: Storing value log head: {Fid:0 Len:194 Offset:222174181}
badger 2019/11/12 23:18:17 INFO: Got compaction priority: {level:0 score:1.73 dropPrefix:[]}
badger 2019/11/12 23:18:17 INFO: Running for level: 0
badger 2019/11/12 23:18:17 DEBUG: LOG Compact. Added 162292 keys. Skipped 0 keys. Iteration took: 73.077138ms
badger 2019/11/12 23:18:17 DEBUG: Discard stats: map[]
badger 2019/11/12 23:18:17 INFO: LOG Compact 0->1, del 1 tables, add 1 tables, took 127.274711ms
badger 2019/11/12 23:18:17 INFO: Compaction for level: 0 DONE
badger 2019/11/12 23:18:17 INFO: Force compaction on level 0 done
```

### Start from Backup

*Locally, I also ended up creating a fake context and disabling watches to just read the backup and not have it actually attach to a cluster but just showing the simple case here. I might also send a PR to make this step easier too when just wanting to read from a static restore.*

```
$ bin/sloop -store-root=/tmp/sloop-restore
```