### PR TITLE
Fix Helm service name and port forwarding

### DIFF
--- a/helm/sloop/README.md
+++ b/helm/sloop/README.md
@@ -6,7 +6,7 @@
 5. Write to yaml file: `helm template . --namespace sloop> sloop-test.yaml`
 6. Apply the yaml file in cluster: `kubectl -n sloop apply -f sloop-test.yaml`
 7. Check if the service is running: `kubectl -n sloop get pods`
-8. (Optional) Use port-forward for debugging:  `kc-aws port-forward -n sloop statefulset/sloop 8080 8000`
+8. (Optional) Use port-forward for debugging:  `kubectl port-forward -n sloop service/sloop 8080:80`
 9. In your browser, hit `localhost:8080` to see the result, you can use sloop test data to check the view
 
 ![SloopTestData](/other/sloop-test.png?raw=true "SloopTestData")

--- a/helm/sloop/templates/service.yaml
+++ b/helm/sloop/templates/service.yaml
@@ -14,4 +14,4 @@ spec:
     protocol: TCP
     targetPort: {{ .Values.service.targetPort }}
   selector:
-    name: sloop
+    app.kubernetes.io/name: {{ .Values.name }}


### PR DESCRIPTION
In the Helm `Service`, the `selector` does not match any of the `labels` of the `StatefulSet`, so the service doesn't actually send traffic to the app. This updates the `selector` to what is [here](https://github.com/salesforce/sloop/blob/4f05081ad2e05a3cb984220de98ddb7478eabee6/helm/sloop/templates/statefulset.yaml#L5). I'm not sure if you wanted a more specific selector, but figured this is a good one to start with.

Now that the service works, it can be used for port-forwarding. Not only is this a better practice, but for some reason, I was having protocol errors forwarding directly to the stateful set that went away after I made this change.

I also updated `kc-aws` to `kubectl`. I'm not sure what that was, but probably some local alias of the original author.