### PR TITLE
Add precise time filtering to event and payload views

### DIFF
--- a/pkg/sloop/queries/params.go
+++ b/pkg/sloop/queries/params.go
@@ -16,8 +16,8 @@ const (
 	NameParam      = "name"
 	NameMatchParam = "namematch" // substring match on name
 	UuidParam      = "uuid"
-	StartDateParam = "start_date"
-	EndDateParam   = "end_date"
+	StartTimeParam = "start_time"
+	EndTimeParam   = "end_time"
 	ClickTimeParam = "click_time"
 	QueryParam     = "query"
 	SortParam      = "sort"

--- a/pkg/sloop/queries/query.go
+++ b/pkg/sloop/queries/query.go
@@ -37,7 +37,12 @@ func GetNamesOfQueries() []string {
 }
 
 func RunQuery(queryName string, params url.Values, tables typed.Tables, maxLookBack time.Duration, requestId string) ([]byte, error) {
-	startTime, endTime := computeTimeRange(params, tables, maxLookBack)
+	startTime, endTime, err := computeTimeRange(params, tables, maxLookBack)
+	if err != nil {
+		glog.Errorf("computeTimeRange failed with error: %v", err)
+		return []byte{}, err
+	}
+
 	fn, ok := funcMap[queryName]
 	if !ok {
 		return []byte{}, fmt.Errorf("Query not found: " + queryName)

--- a/pkg/sloop/queries/timerange.go
+++ b/pkg/sloop/queries/timerange.go
@@ -27,12 +27,11 @@ const minLookback = 1 * time.Minute
 //   We first find the endTime.  If we are looking at historic data, we use the end of the last partitions.  If
 //   that is in the future, we use now().  We don't want to always use now() as that would prevent users from looking
 //   at old data as it would get clipped by maxLookBack
-//
 //   StartTime is just endTime - lookback
 //
 // Using "start_time" and "end_time"
 //
-//   This is straighforward.  These are UTC Unix times
+//   This is straight forward.  These are UTC Unix times
 //
 // TODO: If wall clock is in the middle of the newest partition min-max time we can use it
 func computeTimeRange(params url.Values, tables typed.Tables, maxLookBack time.Duration) (time.Time, time.Time, error) {
@@ -93,11 +92,9 @@ func computeTimeRange(params url.Values, tables typed.Tables, maxLookBack time.D
 	return computedStart, computedEnd, nil
 }
 
-// This looks at our store, and if it has data finds the newest partitions, then finds the end time of that
+// This looks at our store, and if it has data finds the newest partition, then finds the end time of that
 // But if that is in the future we return now
 // This bit of logic is needed for queries with a lookback to determine a good end time
-// For normal operation we general end up with endTime==now(), but if we are viewing a data store in the past
-// we want endTime to be the end of the data set
 func getEndOfTime(tables typed.Tables) time.Time {
 	now := time.Now()
 

--- a/pkg/sloop/queries/timerange.go
+++ b/pkg/sloop/queries/timerange.go
@@ -35,6 +35,11 @@ const minLookback = 1 * time.Minute
 //
 // TODO: If wall clock is in the middle of the newest partition min-max time we can use it
 func computeTimeRange(params url.Values, tables typed.Tables, maxLookBack time.Duration) (time.Time, time.Time, error) {
+	endOfTime := getEndOfTime(tables)
+	return computeTimeRangeInternal(params, endOfTime, maxLookBack)
+}
+
+func computeTimeRangeInternal(params url.Values, endOfTime time.Time, maxLookBack time.Duration) (time.Time, time.Time, error) {
 	lookBackVal := params.Get(LookbackParam)
 	startTimeVal := params.Get(StartTimeParam)
 	endTimeVal := params.Get(EndTimeParam)
@@ -56,8 +61,6 @@ func computeTimeRange(params url.Values, tables typed.Tables, maxLookBack time.D
 			return time.Time{}, time.Time{}, fmt.Errorf("Either %v and %v both need to be set or neither set", StartTimeParam, EndTimeParam)
 		}
 	}
-
-	endOfTime := getEndOfTime(tables)
 
 	if lookBackVal != "" {
 		computedEnd = endOfTime
@@ -90,6 +93,7 @@ func computeTimeRange(params url.Values, tables typed.Tables, maxLookBack time.D
 	}
 
 	return computedStart, computedEnd, nil
+
 }
 
 // This looks at our store, and if it has data finds the newest partition, then finds the end time of that

--- a/pkg/sloop/queries/timerange.go
+++ b/pkg/sloop/queries/timerange.go
@@ -8,60 +8,151 @@
 package queries
 
 import (
+	"fmt"
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/salesforce/sloop/pkg/sloop/store/typed"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped"
 	"net/url"
+	"strconv"
 	"time"
 )
 
-// This computes a start and end time for a given query.  If user specifies a time duration we use it, otherwise
-// we use maxLookBack from config.  For the end time if not specified we want to use newest data in the store.
-// That way we can look at old data sets without clipping.  We know the min and max time of the newest partition
-// but we dont really know the newest record within that range.  For now just use end of newest partiton, but
-// we will improve that later.
-// TODO: Add unit tests
-// TODO: If wall clock is in the middle of the newest partition min-max time we can use it
-func computeTimeRange(params url.Values, tables typed.Tables, maxLookBack time.Duration) (time.Time, time.Time) {
-	now := time.Now()
+const minLookback = 1 * time.Minute
 
-	// If web request specifies a valid lookback use that, else use the config for the store
-	queryDuration := maxLookBack
-	queryLookBack := params.Get(LookbackParam)
-	if queryLookBack != "" {
-		var err error
-		queryDuration, err = time.ParseDuration(queryLookBack)
-		if err != nil {
-			glog.Errorf("Invalid lookback param: %v.  err: %v", queryLookBack, err)
+// This computes a start and end time for a given query.  There are 2 ways this can be specified:
+//
+// Using "lookback":
+//
+//   We first find the endTime.  If we are looking at historic data, we use the end of the last partitions.  If
+//   that is in the future, we use now().  We don't want to always use now() as that would prevent users from looking
+//   at old data as it would get clipped by maxLookBack
+//
+//   StartTime is just endTime - lookback
+//
+// Using "start_time" and "end_time"
+//
+//   This is straighforward.  These are UTC Unix times
+//
+// TODO: If wall clock is in the middle of the newest partition min-max time we can use it
+func computeTimeRange(params url.Values, tables typed.Tables, maxLookBack time.Duration) (time.Time, time.Time, error) {
+	lookBackVal := params.Get(LookbackParam)
+	startTimeVal := params.Get(StartTimeParam)
+	endTimeVal := params.Get(EndTimeParam)
+
+	var computedStart time.Time
+	var computedEnd time.Time
+	var err error
+
+	// Input validations
+	if startTimeVal == "" && endTimeVal == "" && lookBackVal == "" {
+		return time.Time{}, time.Time{}, fmt.Errorf("Time range must be set with either [%v] or both of [%v,%v]", LookbackParam, StartTimeParam, EndTimeParam)
+	}
+	if lookBackVal != "" {
+		if startTimeVal != "" || endTimeVal != "" {
+			return time.Time{}, time.Time{}, fmt.Errorf("When [%v] is set, you can not set either of [%v,%v]", LookbackParam, StartTimeParam, EndTimeParam)
+		}
+	} else {
+		if (startTimeVal == "") != (endTimeVal == "") {
+			return time.Time{}, time.Time{}, fmt.Errorf("Either %v and %v both need to be set or neither set", StartTimeParam, EndTimeParam)
 		}
 	}
-	if queryDuration < 10*time.Minute || queryDuration > maxLookBack {
-		queryDuration = maxLookBack
+
+	endOfTime := getEndOfTime(tables)
+
+	if lookBackVal != "" {
+		computedEnd = endOfTime
+		lookbackRange, err := getTimeRangeFromLookback(lookBackVal)
+		if err != nil {
+			return time.Time{}, time.Time{}, err
+		}
+		computedStart = computedEnd.Add(-1 * lookbackRange)
+	} else {
+		computedStart, computedEnd, err = getTimeRangeFromStartEnd(startTimeVal, endTimeVal)
+		if err != nil {
+			return time.Time{}, time.Time{}, err
+		}
 	}
 
-	// Find the end of the newest store partition and use that as endTime
+	// If the time range ends beyond endOfTime shift it back
+	if computedEnd.After(endOfTime) {
+		shiftBy := computedEnd.Sub(endOfTime)
+		computedStart = computedStart.Add(-1 * shiftBy)
+		computedEnd = computedEnd.Add(-1 * shiftBy)
+	}
+
+	// If the time range is too small, increase it
+	if computedEnd.Sub(computedStart) < minLookback {
+		computedStart = computedEnd.Add(-1 * minLookback)
+	}
+
+	if computedEnd.Sub(computedStart) > maxLookBack {
+		computedStart = computedEnd.Add(-1 * maxLookBack)
+	}
+
+	return computedStart, computedEnd, nil
+}
+
+// This looks at our store, and if it has data finds the newest partitions, then finds the end time of that
+// But if that is in the future we return now
+// This bit of logic is needed for queries with a lookback to determine a good end time
+// For normal operation we general end up with endTime==now(), but if we are viewing a data store in the past
+// we want endTime to be the end of the data set
+func getEndOfTime(tables typed.Tables) time.Time {
+	now := time.Now()
+
 	ok, _, maxPartition, err := tables.GetMinAndMaxPartition()
 	if err != nil || !ok {
 		if err != nil {
 			glog.Errorf("Error getting MinAndMaxPartition: %v", err)
 		}
-		// Store is broken or has no data.  Best we can do is now - queryDuration
-		return now.Add(-1 * queryDuration), now
+		return now
 	}
 
 	_, endTimeOfNewestPartition, err := untyped.GetTimeRangeForPartition(maxPartition)
 	if err != nil {
 		glog.Errorf("Error getting MinAndMaxPartition: %v", err)
-		return now.Add(-1 * queryDuration), now
+		return now
 	}
 
 	// The newest partition ends in the future, so use now instead
 	if endTimeOfNewestPartition.After(now) {
-		return now.Add(-1 * queryDuration), now
+		return now
+	} else {
+		return endTimeOfNewestPartition
+	}
+}
+
+func getTimeRangeFromLookback(lookbackVal string) (time.Duration, error) {
+	queryDuration, err := time.ParseDuration(lookbackVal)
+	if err != nil {
+		glog.Errorf("Invalid lookback param: %v.  err: %v", lookbackVal, err)
+		return 0, err
 	}
 
-	return endTimeOfNewestPartition.Add(-1 * queryDuration), endTimeOfNewestPartition
+	return queryDuration, nil
+}
+
+func getTimeRangeFromStartEnd(startTimeStr string, endTimeStr string) (time.Time, time.Time, error) {
+	var start, end time.Time
+	var err error
+	start, err = parseUnixTimeString(startTimeStr)
+	if err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+	end, err = parseUnixTimeString(endTimeStr)
+	if err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+	return start, end, nil
+}
+
+func parseUnixTimeString(unixStr string) (time.Time, error) {
+	unixNum, err := strconv.ParseInt(unixStr, 10, 64)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Unix(unixNum, 0).UTC(), nil
 }
 
 // This extracts time info from the ResourceSummary value and checks if it overlaps with the query time range.

--- a/pkg/sloop/queries/timerange.go
+++ b/pkg/sloop/queries/timerange.go
@@ -50,21 +50,21 @@ func computeTimeRangeInternal(params url.Values, endOfTime time.Time, maxLookBac
 
 	// Input validations
 	if startTimeVal == "" && endTimeVal == "" && lookBackVal == "" {
-		return time.Time{}, time.Time{}, fmt.Errorf("Time range must be set with either [%v] or both of [%v,%v]", LookbackParam, StartTimeParam, EndTimeParam)
+		return time.Time{}, time.Time{}, fmt.Errorf("Time range must be set with either [%v] or both of [%v,%v] but all 3 were empty", LookbackParam, StartTimeParam, EndTimeParam)
 	}
 	if lookBackVal != "" {
 		if startTimeVal != "" || endTimeVal != "" {
-			return time.Time{}, time.Time{}, fmt.Errorf("When [%v] is set, you can not set either of [%v,%v]", LookbackParam, StartTimeParam, EndTimeParam)
+			return time.Time{}, time.Time{}, fmt.Errorf("When [%v] is set, you can not set either of [%v,%v].  Got (%v,%v,%v) respectively", LookbackParam, StartTimeParam, EndTimeParam, lookBackVal, startTimeVal, endTimeVal)
 		}
 	} else {
-		if (startTimeVal == "") != (endTimeVal == "") {
-			return time.Time{}, time.Time{}, fmt.Errorf("Either %v and %v both need to be set or neither set", StartTimeParam, EndTimeParam)
+		if (startTimeVal == "") || (endTimeVal == "") {
+			return time.Time{}, time.Time{}, fmt.Errorf("Either %v and %v both need to be set or neither set.  Got (%v,%v) respectively", StartTimeParam, EndTimeParam, startTimeVal, endTimeVal)
 		}
 	}
 
 	if lookBackVal != "" {
 		computedEnd = endOfTime
-		lookbackRange, err := getTimeRangeFromLookback(lookBackVal)
+		lookbackRange, err := getDurationFromLookback(lookBackVal)
 		if err != nil {
 			return time.Time{}, time.Time{}, err
 		}
@@ -124,7 +124,7 @@ func getEndOfTime(tables typed.Tables) time.Time {
 	}
 }
 
-func getTimeRangeFromLookback(lookbackVal string) (time.Duration, error) {
+func getDurationFromLookback(lookbackVal string) (time.Duration, error) {
 	queryDuration, err := time.ParseDuration(lookbackVal)
 	if err != nil {
 		glog.Errorf("Invalid lookback param: %v.  err: %v", lookbackVal, err)

--- a/pkg/sloop/webfiles/filter.js
+++ b/pkg/sloop/webfiles/filter.js
@@ -89,9 +89,11 @@ function setFiltersAndReturnQueryUrl(defaultLookback, defaultKind, defaultNamesp
 
     namematch = setText("namematch", "filternamematch", "")
 
-    query =           populateDropdownFromQuery("query",     "filterquery",     "EventHeatMap",  "/data?query=Queries");
-    ns =              populateDropdownFromQuery("namespace", "filternamespace", defaultNamespace, "/data?query=Namespaces");
-    kind =            populateDropdownFromQuery("kind",      "filterkind",      defaultKind,      "/data?query=Kinds");
+    // For the "query" query its a bit of a hack to need to pass in a lookback
+    // TODO: In the query library add some metadata per query so queries can indicate they dont need a lookback
+    query =           populateDropdownFromQuery("query",     "filterquery",     "EventHeatMap",  "/data?query=Queries&lookback="+lookback);
+    ns =              populateDropdownFromQuery("namespace", "filternamespace", defaultNamespace, "/data?query=Namespaces&lookback="+lookback);
+    kind =            populateDropdownFromQuery("kind",      "filterkind",      defaultKind,      "/data?query=Kinds&lookback="+lookback);
 
     dataQuery = "/data?query="+query+"&namespace="+ns+"&lookback="+lookback+"&kind="+kind+"&sort="+sort+"&namematch="+namematch
     return dataQuery

--- a/pkg/sloop/webfiles/filter.js
+++ b/pkg/sloop/webfiles/filter.js
@@ -89,8 +89,6 @@ function setFiltersAndReturnQueryUrl(defaultLookback, defaultKind, defaultNamesp
 
     namematch = setText("namematch", "filternamematch", "")
 
-    // For the "query" query its a bit of a hack to need to pass in a lookback
-    // TODO: In the query library add some metadata per query so queries can indicate they dont need a lookback
     query =           populateDropdownFromQuery("query",     "filterquery",     "EventHeatMap",  "/data?query=Queries&lookback="+lookback);
     ns =              populateDropdownFromQuery("namespace", "filternamespace", defaultNamespace, "/data?query=Namespaces&lookback="+lookback);
     kind =            populateDropdownFromQuery("kind",      "filterkind",      defaultKind,      "/data?query=Kinds&lookback="+lookback);

--- a/pkg/sloop/webfiles/resource.html
+++ b/pkg/sloop/webfiles/resource.html
@@ -29,14 +29,13 @@ For full license text, see LICENSE.txt file in the repo root or https://opensour
 
     <a href="{{.SelfUrl}}" target="_blank">Open In New Tab</a><br>
 
-
     {{if ne (len .Links) 0 }}
         <h2>Links</h2>
         {{range .Links}}<a href="{{.Url}}" target="_blank">{{.Text}}</a><br>{{end}}
     {{end}}
 
     <div id="resource_payload">
-        <h2>Payloads from ${ getStartTime} to ${getEndTime}</h2>
+        <h2>Viewing range {{.ClickTime}} +/- {{.PlusMinusTime}}</h2>
         <table id="resource_event_table">
             <tr>
                 <th>Payload Link</th>
@@ -116,20 +115,6 @@ new Vue({
                 if (a[this.currentSortBy] > b[this.currentSortBy]) return direction;
                 return 0;
             });
-        },
-        getStartTime: function () {
-            payloadTimeList = this.resPayload.map(function (val) {
-                formattedTime = new Date(val.payloadTime/1000000).toISOString().split('T').join(' ');
-                return  formattedTime;
-            });
-            return payloadTimeList[0];
-        },
-        getEndTime: function () {
-            payloadTimeList = this.resPayload.map(function (val) {
-                formattedTime = new Date(val.payloadTime/1000000).toISOString().split('T').join(' ');
-                return  formattedTime;
-            });
-            return payloadTimeList[payloadTimeList.length-1];
         },
     }
 });


### PR DESCRIPTION
Before the queries for events and payloads on the resource popup were passing in lookback=5m, but there was code that checked for lookback<30 and changed it to maxLookBack (usually 2 weeks).

This PR adds a second way to specify query time with start_time + end_time.  It also changes the minimum lookback to 1m, and if less just bumps it to 1m.

The benefit of this is now when users click on part of a timeline they only see resources and payloads for +/- 15m, which is helpful for long-lived resources where you just want to investigate one bit of time.  In the future we can make the range adjustable for the user.