### PR TITLE
Fix defaultLookback if not set in config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go install -ldflags "-s" -installsuffix cgo -v ./pkg/...
 
 docker:
-	docker build . -t sloopimage/sloop
+	docker build . -t sloop
 
 generate:
 	go generate ./pkg/...


### PR DESCRIPTION
Problem: with the new timerange query code, it needs a valid maxLookback but the config defaults to empty string
Solution: start with a default value

Also, fix the makefile docker image tag so it is not the same as the one in dockerhub