### PR TITLE
Update readme to link to Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Users can install sloop by using helm chart now, for instructions refer [helm re
 
 ### Precompiled Binaries
 
-_DockerHub images coming soon._
+- Docker: [`sloopimage/sloop`](https://hub.docker.com/r/sloopimage/sloop)
 
 ### Build from Source
 

--- a/helm/sloop/values.yaml
+++ b/helm/sloop/values.yaml
@@ -2,9 +2,7 @@ serviceAccountName: sloop
 name: sloop
 replicas: 1
 image:
-  # for now, user needs to set their own imag tag,for example:test-20191009
   tag: latest
-  # for now, user needs to set their own image
   repository: sloopimage/sloop
 persistentVolume:
 ## If defined it will specify the storageClass for the statefulSet


### PR DESCRIPTION
The readme still says "DockerHub images coming soon" even though it looks like the official Dockage is published now (ref: #63, #65).

EDIT(1):
I also updated the Helm chart comment to reflect that there's a public image now.

~EDIT(2):
I also update "Local Docker Run" to use public image. `make docker` now tags with `sloopimage/sloop` so "Local Docker Run" will not work correctly. It would be weird to have people tag with a public image, so just recommend using the public image itself.~
Nevermind, this was fixed in https://github.com/salesforce/sloop/pull/67