### PR TITLE
Only require valid context when watching

### DIFF
--- a/pkg/sloop/ingress/kubeclient.go
+++ b/pkg/sloop/ingress/kubeclient.go
@@ -54,7 +54,7 @@ func MakeKubernetesClient(masterURL string, kubeContext string) (kubernetes.Inte
 		return nil, err
 	}
 
-	glog.Infof("Created k8sclient with context=%v, masterURL=%v, configFile=%v.", config.Host, clientConfig.ConfigAccess().GetLoadingPrecedence())
+	glog.Infof("Created k8sclient with context=%v, masterURL=%v, configFile=%v.", kubeContext, config.Host, clientConfig.ConfigAccess().GetLoadingPrecedence())
 	return clientset, nil
 }
 


### PR DESCRIPTION
This is a fix to https://github.com/salesforce/sloop/issues/58, which contains more details about the problem itself. The problem was originally raised in https://github.com/salesforce/sloop/pull/56#issuecomment-552969933.

As for the fix, this just splits out a new method from `MakeKubernetesClient()` called `GetKubernetesContext()` that just gets the context, but does not create the client. Then it moves the call to `MakeKubernetesClient()` inside of `if !conf.DisableKubeWatcher { ... }` with the resolved context from `GetKubernetesContext()` so the user preference is only resolved against the config file once.

Fixes https://github.com/salesforce/sloop/issues/58