### PR TITLE
Use Values.name for configMap name

### DIFF
--- a/helm/sloop/templates/statefulset.yaml
+++ b/helm/sloop/templates/statefulset.yaml
@@ -63,7 +63,7 @@ spec:
           sizeLimit: {{ .Values.persistentVolume.sizeLimit }}
         name: sloop-data
       - configMap:
-          name: sloop
+          name: {{ .Values.name }}
         name: sloopconfig
       serviceAccountName: {{ .Values.serviceAccountName }}
   volumeClaimTemplates:


### PR DESCRIPTION
The created config map uses Values.name, so the pod reference
should also use it otherwise the pod fails to start