### PR TITLE
Tweak Badger GC and expose several Badger config options

### DIFF
--- a/pkg/sloop/server/internal/config/config.go
+++ b/pkg/sloop/server/internal/config/config.go
@@ -51,7 +51,6 @@ type SloopConfig struct {
 	ApiServerHost           string        `json:"apiServerHost"`
 	WatchCrds               bool          `json:"watchCrds"`
 	RestoreDatabaseFile     string        `json:"restoreDatabaseFile"`
-	// https://godoc.org/github.com/dgraph-io/badger#DB.RunValueLogGC
 	BadgerDiscardRatio      float64       `json:"badgerDiscardRatio"`
 	BadgerVLogGCFreq        time.Duration `json:"badgerVLogGCFreq"`
 	BadgerMaxTableSize      int64         `json:"badgerMaxTableSize"`
@@ -91,8 +90,7 @@ func registerFlags(fs *flag.FlagSet, config *SloopConfig) {
 	fs.BoolVar(&config.BadgerKeepL0InMemory, "badger-keep-l0-in-memory", true, "Keeps all level 0 tables in memory for faster writes and compactions")
 	fs.Int64Var(&config.BadgerVLogFileSize, "badger-vlog-file-size", 0, "Max size in bytes per value log file. 0 = use badger default")
 	fs.UintVar(&config.BadgerVLogMaxEntries, "badger-vlog-max-entries", 0, "Max number of entries per value log files. 0 = use badger default")
-	fs.BoolVar(&config.BadgerUseLSMOnlyOptions, "badger-use-lsm-only-options", true, "Sets a higher valueThreshold so values would be collocated with LSM tree reducing disk usage")
-
+	fs.BoolVar(&config.BadgerUseLSMOnlyOptions, "badger-use-lsm-only-options", true, "Sets a higher valueThreshold so values would be collocated with LSM tree reducing vlog disk usage")
 }
 
 // This will first check if a config file is specified on cmd line using a temporary flagSet

--- a/pkg/sloop/server/internal/config/config.go
+++ b/pkg/sloop/server/internal/config/config.go
@@ -53,8 +53,13 @@ type SloopConfig struct {
 	RestoreDatabaseFile     string        `json:"restoreDatabaseFile"`
 	// https://godoc.org/github.com/dgraph-io/badger#DB.RunValueLogGC
 	BadgerDiscardRatio      float64       `json:"badgerDiscardRatio"`
-	BadgerValueLogGC        time.Duration `json:"badgerValueLogGC"`
-
+	BadgerVLogGCFreq        time.Duration `json:"badgerVLogGCFreq"`
+	BadgerVLogGCLoop        bool          `json:"badgerVLogGCLoop"`
+	BadgerMaxTableSize      int64         `json:"badgerMaxTableSize"`
+	BadgerKeepL0InMemory    bool          `json:"badgerKeepL0InMemory"`
+	BadgerVLogFileSize      int64         `json:"badgerVLogFileSize"`
+	BadgerVLogMaxEntries    uint          `json:"badgerVLogMaxEntries"`
+	BadgerUseLSMOnlyOptions bool          `json:"badgerUseLSMOnlyOptions"`
 }
 
 func registerFlags(fs *flag.FlagSet, config *SloopConfig) {
@@ -83,7 +88,14 @@ func registerFlags(fs *flag.FlagSet, config *SloopConfig) {
 	fs.BoolVar(&config.WatchCrds, "watch-crds", true, "Watch for activity for CRDs")
 	fs.StringVar(&config.RestoreDatabaseFile, "restore-database-file", "", "Restore database from backup file into current context.")
 	fs.Float64Var(&config.BadgerDiscardRatio, "badger-discard-ratio", 0.01, "Badger value log GC uses this value to decide if it wants to compact a vlog file.  Smaller values free more disk space but use more computing resources")
-	fs.DurationVar(&config.BadgerValueLogGC, "badger-value-log-gc", time.Minute*5, "Frequency of running badger's ValueLogGC")
+	fs.DurationVar(&config.BadgerVLogGCFreq, "badger-vlog-gc-freq", time.Minute*5, "Frequency of running badger's ValueLogGC")
+	fs.BoolVar(&config.BadgerVLogGCLoop, "badger-vlog-gc-loop", true, "If set, rung badger ValueLogGC in a loop until it finds no data to free")
+	fs.Int64Var(&config.BadgerMaxTableSize, "badger-max-table-size", 0, "Max LSM table size in bytes")
+	fs.BoolVar(&config.BadgerKeepL0InMemory, "badger-keep-l0-in-memory", true, "Keeps all level 0 tables in memory for faster writes and compactions")
+	fs.Int64Var(&config.BadgerVLogFileSize, "badger-vlog-file-size", 0, "Max size in bytes per value log file")
+	fs.UintVar(&config.BadgerVLogMaxEntries, "badger-vlog-max-entries", 0, "Max number of entries per value log files")
+	fs.BoolVar(&config.BadgerUseLSMOnlyOptions, "badger-use-lsm-only-options", true, "Sets a higher valueThreshold so values would be collocated with LSM tree reducing disk usage")
+
 }
 
 // This will first check if a config file is specified on cmd line using a temporary flagSet

--- a/pkg/sloop/server/internal/config/config.go
+++ b/pkg/sloop/server/internal/config/config.go
@@ -51,6 +51,10 @@ type SloopConfig struct {
 	ApiServerHost           string        `json:"apiServerHost"`
 	WatchCrds               bool          `json:"watchCrds"`
 	RestoreDatabaseFile     string        `json:"restoreDatabaseFile"`
+	// https://godoc.org/github.com/dgraph-io/badger#DB.RunValueLogGC
+	BadgerDiscardRatio      float64       `json:"badgerDiscardRatio"`
+	BadgerValueLogGC        time.Duration `json:"badgerValueLogGC"`
+
 }
 
 func registerFlags(fs *flag.FlagSet, config *SloopConfig) {
@@ -78,6 +82,8 @@ func registerFlags(fs *flag.FlagSet, config *SloopConfig) {
 	fs.StringVar(&config.ApiServerHost, "apiserver-host", "", "Kubernetes API server endpoint")
 	fs.BoolVar(&config.WatchCrds, "watch-crds", true, "Watch for activity for CRDs")
 	fs.StringVar(&config.RestoreDatabaseFile, "restore-database-file", "", "Restore database from backup file into current context.")
+	fs.Float64Var(&config.BadgerDiscardRatio, "badger-discard-ratio", 0.01, "Badger value log GC uses this value to decide if it wants to compact a vlog file.  Smaller values free more disk space but use more computing resources")
+	fs.DurationVar(&config.BadgerValueLogGC, "badger-value-log-gc", time.Minute*5, "Frequency of running badger's ValueLogGC")
 }
 
 // This will first check if a config file is specified on cmd line using a temporary flagSet

--- a/pkg/sloop/server/server.go
+++ b/pkg/sloop/server/server.go
@@ -57,7 +57,16 @@ func RealMain() error {
 	factory := &badgerwrap.BadgerFactory{}
 
 	storeRootWithKubeContext := path.Join(conf.StoreRoot, kubeContext)
-	db, err := untyped.OpenStore(factory, storeRootWithKubeContext, time.Duration(1)*time.Hour, conf.BadgerMaxTableSize, conf.BadgerKeepL0InMemory, conf.BadgerVLogFileSize, conf.BadgerVLogMaxEntries, conf.BadgerUseLSMOnlyOptions)
+	storeConfig := &untyped.Config{
+		RootPath:                storeRootWithKubeContext,
+		ConfigPartitionDuration: time.Duration(1) * time.Hour,
+		BadgerMaxTableSize:      conf.BadgerMaxTableSize,
+		BadgerKeepL0InMemory:    conf.BadgerKeepL0InMemory,
+		BadgerVLogFileSize:      conf.BadgerVLogFileSize,
+		BadgerVLogMaxEntries:    conf.BadgerVLogMaxEntries,
+		BadgerUseLSMOnlyOptions: conf.BadgerUseLSMOnlyOptions,
+	}
+	db, err := untyped.OpenStore(factory, storeConfig)
 	if err != nil {
 		return errors.Wrap(err, "failed to init untyped store")
 	}
@@ -111,10 +120,9 @@ func RealMain() error {
 			StoreRoot:          conf.StoreRoot,
 			Freq:               conf.CleanupFrequency,
 			TimeLimit:          conf.MaxLookback,
-			SizeLimitMb:        conf.MaxDiskMb,
+			SizeLimitBytes:     conf.MaxDiskMb * 1024 * 1024,
 			BadgerDiscardRatio: conf.BadgerDiscardRatio,
 			BadgerVLogGCFreq:   conf.BadgerVLogGCFreq,
-			BadgerVLogGCLoop:   conf.BadgerVLogGCLoop,
 		}
 		storemgr = storemanager.NewStoreManager(tables, storeCfg, fs)
 		storemgr.Start()

--- a/pkg/sloop/store/untyped/badgerwrap/api.go
+++ b/pkg/sloop/store/untyped/badgerwrap/api.go
@@ -44,7 +44,7 @@ type DB interface {
 	//	NewTransactionAt(readTs uint64, update bool) *Txn
 	//	NewWriteBatch() *WriteBatch
 	//	PrintHistogram(keyPrefix []byte)
-	//	RunValueLogGC(discardRatio float64) error
+	RunValueLogGC(discardRatio float64) error
 	//	SetDiscardTs(ts uint64)
 	//	Subscribe(ctx context.Context, cb func(kv *KVList), prefixes ...[]byte) error
 	//	VerifyChecksum() error

--- a/pkg/sloop/store/untyped/badgerwrap/badger.go
+++ b/pkg/sloop/store/untyped/badgerwrap/badger.go
@@ -84,6 +84,10 @@ func (b *BadgerDb) Load(r io.Reader, maxPendingWrites int) error {
 	return b.db.Load(r, maxPendingWrites)
 }
 
+func (b *BadgerDb) RunValueLogGC(discardRatio float64) error {
+	return b.db.RunValueLogGC(discardRatio)
+}
+
 // Transaction
 
 func (t *BadgerTxn) Get(key []byte) (Item, error) {

--- a/pkg/sloop/store/untyped/badgerwrap/mock.go
+++ b/pkg/sloop/store/untyped/badgerwrap/mock.go
@@ -118,6 +118,10 @@ func (b *MockDb) Load(r io.Reader, maxPendingWrites int) error {
 	return nil
 }
 
+func (b *MockDb) RunValueLogGC(discardRatio float64) error {
+	return nil
+}
+
 // Transaction
 
 func (t *MockTxn) Get(key []byte) (Item, error) {

--- a/pkg/sloop/store/untyped/store.go
+++ b/pkg/sloop/store/untyped/store.go
@@ -35,9 +35,10 @@ func OpenStore(factory badgerwrap.Factory, config *Config) (badgerwrap.DB, error
 	if err != nil {
 		glog.Infof("mkdir failed with %v", err)
 	}
-	// For now using a temp name because this all need to be replaced when we add real table/partition support
+
 	var opts badger.Options
 	if config.BadgerUseLSMOnlyOptions {
+		// LSMOnlyOptions uses less disk space for vlog files.  See the comments on the LSMOnlyOptions() func for details
 		opts = badger.LSMOnlyOptions(config.RootPath)
 	} else {
 		opts = badger.DefaultOptions(config.RootPath)

--- a/pkg/sloop/store/untyped/store.go
+++ b/pkg/sloop/store/untyped/store.go
@@ -16,21 +16,45 @@ import (
 	"time"
 )
 
-func OpenStore(factory badgerwrap.Factory, rootPath string, configPartitionDuration time.Duration) (badgerwrap.DB, error) {
+func OpenStore(factory badgerwrap.Factory, rootPath string, configPartitionDuration time.Duration, badgerMaxTableSize int64, badgerKeepL0InMemory bool, badgerVLogFileSize int64, badgerVLogMaxEntries uint, badgerUseLSMOnlyOptions bool) (badgerwrap.DB, error) {
+	if configPartitionDuration != time.Hour && configPartitionDuration != 24*time.Hour {
+		return nil, fmt.Errorf("Only hour and day partitionDurations are supported")
+	}
+
 	err := os.MkdirAll(rootPath, 0755)
 	if err != nil {
 		glog.Infof("mkdir failed with %v", err)
 	}
 	// For now using a temp name because this all need to be replaced when we add real table/partition support
-	opts := badger.DefaultOptions(rootPath)
+	var opts badger.Options
+	if badgerUseLSMOnlyOptions {
+		opts = badger.LSMOnlyOptions(rootPath)
+	} else {
+		opts = badger.DefaultOptions(rootPath)
+	}
+
+	if badgerMaxTableSize != 0 {
+		opts = opts.WithMaxTableSize(badgerMaxTableSize)
+	}
+	opts.KeepL0InMemory = badgerKeepL0InMemory
+	if badgerVLogFileSize != 0 {
+		opts = opts.WithValueLogFileSize(badgerVLogFileSize)
+	}
+	if badgerVLogMaxEntries != 0 {
+		opts = opts.WithValueLogMaxEntries(uint32(badgerVLogMaxEntries))
+	}
 
 	db, err := factory.Open(opts)
 	if err != nil {
 		return nil, fmt.Errorf("badger.OpenStore failed with: %v", err)
 	}
 
-	if configPartitionDuration != time.Hour && configPartitionDuration != 24*time.Hour {
-		return nil, fmt.Errorf("Only hour and day partitionDurations are supported")
+	glog.Infof("BadgerDB Options: %+v", opts)
+	lsm, vlog := db.Size()
+	glog.Infof("BadgerDB Size lsm=%v, vlog=%v", lsm, vlog)
+	tables := db.Tables(true)
+	for _, table := range tables {
+		glog.Infof("BadgerDB TABLE id=%v keycount=%v level=%v left=%v right=%v", table.ID, table.KeyCount, table.Level, string(table.Left), string(table.Right))
 	}
 
 	partitionDuration = configPartitionDuration

--- a/pkg/sloop/storemanager/stats.go
+++ b/pkg/sloop/storemanager/stats.go
@@ -87,7 +87,7 @@ func getDirSizeRecursive(root string, fs *afero.Afero) (uint64, map[string]int, 
 }
 
 func emitMetrics(stats *storeStats) {
-	metricStoreSizeOnDiskMb.Set(float64(stats.DiskSizeBytes))
+	metricStoreSizeOnDiskMb.Set(float64(stats.DiskSizeBytes / 1024 / 1024))
 	for k, v := range stats.LevelToKeyCount {
 		metricBadgerKeys.WithLabelValues(fmt.Sprintf("%v", k)).Set(float64(v))
 	}
@@ -95,7 +95,7 @@ func emitMetrics(stats *storeStats) {
 		metricBadgerTables.WithLabelValues(fmt.Sprintf("%v", k)).Set(float64(v))
 	}
 	metricBadgerLsmFileCount.Set(float64(stats.DiskLsmFileCount))
-	metricBadgerLsmSizeMb.Set(float64(stats.DiskLsmBytes))
+	metricBadgerLsmSizeMb.Set(float64(stats.DiskLsmBytes / 1024 / 1024))
 	metricBadgerVLogFileCount.Set(float64(stats.DiskVlogFileCount))
-	metricBadgerVLogSizeMb.Set(float64(stats.DiskVlogBytes))
+	metricBadgerVLogSizeMb.Set(float64(stats.DiskVlogBytes / 1024 / 1024))
 }

--- a/pkg/sloop/storemanager/stats.go
+++ b/pkg/sloop/storemanager/stats.go
@@ -21,12 +21,12 @@ var (
 	metricBadgerTables        = promauto.NewGaugeVec(prometheus.GaugeOpts{Name: "sloop_badger_tables"}, []string{"level"})
 	metricBadgerLsmFileCount  = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_badger_lsmfilecount"})
 	metricBadgerLsmSizeMb     = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_badger_lsmsizemb"})
-	metricBadgerVlogFileCount = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_badger_vlogfilecount"})
-	metricBadgerVlogSizeMb    = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_badger_vlogsizemb"})
+	metricBadgerVLogFileCount = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_badger_vlogfilecount"})
+	metricBadgerVLogSizeMb    = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_badger_vlogsizemb"})
 )
 
 type storeStats struct {
-	Timestamp         time.Time
+	timestamp         time.Time
 	DiskSizeBytes     uint64
 	DiskLsmBytes      uint64
 	DiskLsmFileCount  int
@@ -40,7 +40,7 @@ func generateStats(storeRoot string, db badgerwrap.DB, fs *afero.Afero) *storeSt
 	ret := &storeStats{}
 	ret.LevelToKeyCount = make(map[int]uint64)
 	ret.LevelToTableCount = make(map[int]int)
-	ret.Timestamp = time.Now()
+	ret.timestamp = time.Now()
 
 	totalSizeBytes, extFileCount, extByteCount, err := getDirSizeRecursive(storeRoot, fs)
 	if err != nil {
@@ -96,6 +96,6 @@ func emitMetrics(stats *storeStats) {
 	}
 	metricBadgerLsmFileCount.Set(float64(stats.DiskLsmFileCount))
 	metricBadgerLsmSizeMb.Set(float64(stats.DiskLsmBytes))
-	metricBadgerVlogFileCount.Set(float64(stats.DiskVlogFileCount))
-	metricBadgerVlogSizeMb.Set(float64(stats.DiskVlogBytes))
+	metricBadgerVLogFileCount.Set(float64(stats.DiskVlogFileCount))
+	metricBadgerVLogSizeMb.Set(float64(stats.DiskVlogBytes))
 }

--- a/pkg/sloop/storemanager/stats.go
+++ b/pkg/sloop/storemanager/stats.go
@@ -1,0 +1,101 @@
+package storemanager
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/salesforce/sloop/pkg/sloop/store/untyped/badgerwrap"
+	"github.com/spf13/afero"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const vlogExt = ".vlog" // value log data
+const sstExt = ".sst"   // LSM data
+
+var (
+	metricStoreSizeOnDiskMb   = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_store_sizeondiskmb"})
+	metricBadgerKeys          = promauto.NewGaugeVec(prometheus.GaugeOpts{Name: "sloop_badger_keys"}, []string{"level"})
+	metricBadgerTables        = promauto.NewGaugeVec(prometheus.GaugeOpts{Name: "sloop_badger_tables"}, []string{"level"})
+	metricBadgerLsmFileCount  = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_badger_lsmfilecount"})
+	metricBadgerLsmSizeMb     = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_badger_lsmsizemb"})
+	metricBadgerVlogFileCount = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_badger_vlogfilecount"})
+	metricBadgerVlogSizeMb    = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_badger_vlogsizemb"})
+)
+
+type storeStats struct {
+	Timestamp         time.Time
+	DiskSizeBytes     uint64
+	DiskLsmBytes      uint64
+	DiskLsmFileCount  int
+	DiskVlogBytes     uint64
+	DiskVlogFileCount int
+	LevelToKeyCount   map[int]uint64
+	LevelToTableCount map[int]int
+}
+
+func generateStats(storeRoot string, db badgerwrap.DB, fs *afero.Afero) *storeStats {
+	ret := &storeStats{}
+	ret.LevelToKeyCount = make(map[int]uint64)
+	ret.LevelToTableCount = make(map[int]int)
+	ret.Timestamp = time.Now()
+
+	totalSizeBytes, extFileCount, extByteCount, err := getDirSizeRecursive(storeRoot, fs)
+	if err != nil {
+		// Swallowing on purpose as we still want the other stats
+		glog.Errorf("Failed to check storage size on disk: %v", err)
+	}
+	ret.DiskSizeBytes = totalSizeBytes
+	ret.DiskLsmFileCount = extFileCount[sstExt]
+	ret.DiskLsmBytes = extByteCount[sstExt]
+	ret.DiskVlogFileCount = extFileCount[vlogExt]
+	ret.DiskVlogBytes = extByteCount[vlogExt]
+
+	tables := db.Tables(true)
+	for _, table := range tables {
+		glog.V(2).Infof("BadgerDB TABLE id=%v keycount=%v level=%v left=%q right=%q", table.ID, table.KeyCount, table.Level, string(table.Left), string(table.Right))
+		ret.LevelToTableCount[table.Level] += 1
+		ret.LevelToKeyCount[table.Level] += table.KeyCount
+	}
+
+	glog.Infof("Finished updating store stats: %+v", ret)
+	return ret
+}
+
+// Returns total size, count of files by extension, count of bytes by extension
+func getDirSizeRecursive(root string, fs *afero.Afero) (uint64, map[string]int, map[string]uint64, error) {
+	var totalSize uint64
+	var extFileCount = make(map[string]int)
+	var extByteCount = make(map[string]uint64)
+
+	err := fs.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if !info.IsDir() {
+			totalSize += uint64(info.Size())
+			ext := filepath.Ext(path)
+			extFileCount[ext] += 1
+			extByteCount[ext] += uint64(info.Size())
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, extFileCount, extByteCount, err
+	}
+
+	return totalSize, extFileCount, extByteCount, nil
+}
+
+func emitMetrics(stats *storeStats) {
+	metricStoreSizeOnDiskMb.Set(float64(stats.DiskSizeBytes))
+	for k, v := range stats.LevelToKeyCount {
+		metricBadgerKeys.WithLabelValues(fmt.Sprintf("%v", k)).Set(float64(v))
+	}
+	for k, v := range stats.LevelToTableCount {
+		metricBadgerTables.WithLabelValues(fmt.Sprintf("%v", k)).Set(float64(v))
+	}
+	metricBadgerLsmFileCount.Set(float64(stats.DiskLsmFileCount))
+	metricBadgerLsmSizeMb.Set(float64(stats.DiskLsmBytes))
+	metricBadgerVlogFileCount.Set(float64(stats.DiskVlogFileCount))
+	metricBadgerVlogSizeMb.Set(float64(stats.DiskVlogBytes))
+}

--- a/pkg/sloop/storemanager/stats_test.go
+++ b/pkg/sloop/storemanager/stats_test.go
@@ -23,9 +23,13 @@ func Test_GetDirSizeRecursive(t *testing.T) {
 	fs.WriteFile(path.Join(someDir, "KEYREGISTRY"), []byte("u"), 0700)
 	fs.WriteFile(path.Join(someDir, "MANIFEST"), []byte("u"), 0700)
 
+	subDir := path.Join(someDir, "subDir")
+	fs.Mkdir(subDir, 0700)
+	fs.WriteFile(path.Join(subDir, "randomFile"), []byte("abc"), 0700)
+
 	fileSize, extFileCount, extByteCount, err := getDirSizeRecursive(someDir, &fs)
 	assert.Nil(t, err)
-	assert.Equal(t, uint64(40), fileSize)
-	assert.Equal(t, map[string]int(map[string]int{"": 2, ".sst": 4, ".vlog": 3}), extFileCount)
-	assert.Equal(t, map[string]uint64(map[string]uint64{"": 2, ".sst": 30, ".vlog": 8}), extByteCount)
+	assert.Equal(t, uint64(43), fileSize)
+	assert.Equal(t, map[string]int(map[string]int{"": 3, ".sst": 4, ".vlog": 3}), extFileCount)
+	assert.Equal(t, map[string]uint64(map[string]uint64{"": 5, ".sst": 30, ".vlog": 8}), extByteCount)
 }

--- a/pkg/sloop/storemanager/stats_test.go
+++ b/pkg/sloop/storemanager/stats_test.go
@@ -1,0 +1,31 @@
+package storemanager
+
+import (
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"path"
+	"testing"
+)
+
+func Test_GetDirSizeRecursive(t *testing.T) {
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+	fs.MkdirAll(someDir, 0700)
+	// 3 vlog files
+	fs.WriteFile(path.Join(someDir, "000010.vlog"), []byte("a"), 0700)
+	fs.WriteFile(path.Join(someDir, "000011.vlog"), []byte("aa"), 0700)
+	fs.WriteFile(path.Join(someDir, "000012.vlog"), []byte("aaaaa"), 0700)
+	// 4 sst files
+	fs.WriteFile(path.Join(someDir, "000070.sst"), []byte("zzzzzz"), 0700)
+	fs.WriteFile(path.Join(someDir, "000071.sst"), []byte("zzzzzzz"), 0700)
+	fs.WriteFile(path.Join(someDir, "000072.sst"), []byte("zzzzzzzz"), 0700)
+	fs.WriteFile(path.Join(someDir, "000073.sst"), []byte("zzzzzzzzz"), 0700)
+	// Other
+	fs.WriteFile(path.Join(someDir, "KEYREGISTRY"), []byte("u"), 0700)
+	fs.WriteFile(path.Join(someDir, "MANIFEST"), []byte("u"), 0700)
+
+	fileSize, extFileCount, extByteCount, err := getDirSizeRecursive(someDir, &fs)
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(40), fileSize)
+	assert.Equal(t, map[string]int(map[string]int{"": 2, ".sst": 4, ".vlog": 3}), extFileCount)
+	assert.Equal(t, map[string]uint64(map[string]uint64{"": 2, ".sst": 30, ".vlog": 8}), extByteCount)
+}

--- a/pkg/sloop/storemanager/storemanager.go
+++ b/pkg/sloop/storemanager/storemanager.go
@@ -94,7 +94,7 @@ func (sm *StoreManager) gcLoop() {
 		} else {
 			metricGcFailedCount.Inc()
 		}
-		metricGcLatency.Add(time.Since(before).Seconds())
+		metricGcLatency.Set(time.Since(before).Seconds())
 		glog.Infof("GC finished in %v with return %q.  Next run in %v", time.Since(before), err, sm.config.Freq)
 		sm.sleeper.Sleep(sm.config.Freq)
 	}
@@ -118,7 +118,7 @@ func (sm *StoreManager) vlogGcLoop() {
 			err := sm.tables.Db().RunValueLogGC(sm.config.BadgerDiscardRatio)
 			metricValueLogGcRunning.Set(0)
 			metricValueLogGcRunCount.Add(1)
-			metricValueLogGcLatency.Add(time.Since(before).Seconds())
+			metricValueLogGcLatency.Set(time.Since(before).Seconds())
 			glog.Infof("RunValueLogGC(%v) run took %v and returned %q", sm.config.BadgerDiscardRatio, time.Since(before), err)
 			if err != nil {
 				break

--- a/pkg/sloop/storemanager/storemanager_test.go
+++ b/pkg/sloop/storemanager/storemanager_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/salesforce/sloop/pkg/sloop/store/typed"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped/badgerwrap"
-	"github.com/spf13/afero"
 )
 
 var (
@@ -33,31 +32,21 @@ var (
 	someUid       = "123232"
 )
 
-func Test_GetDirSizeRecursive(t *testing.T) {
-	fs := afero.Afero{Fs: afero.NewMemMapFs()}
-	fs.MkdirAll(someDir, 0700)
-	fs.WriteFile(somePath, []byte("abcdfdfdfd"), 0700)
-
-	fileSize, err := getDirSizeRecursive(someDir, &fs)
-	assert.Nil(t, err)
-	assert.NotZero(t, fileSize)
-}
-
 func Test_cleanUpFileSizeCondition_True(t *testing.T) {
-	fs := afero.Afero{Fs: afero.NewMemMapFs()}
-	fs.MkdirAll(someDir, 0700)
-	fs.WriteFile(somePath, []byte("abcdfdfdfd"), 0700)
+	stats := &storeStats{
+		DiskSizeBytes: 10,
+	}
 
-	flag := cleanUpFileSizeCondition(someDir, 3, &fs)
+	flag := cleanUpFileSizeCondition(stats, 3)
 	assert.True(t, flag)
 }
 
 func Test_cleanUpFileSizeCondition_False(t *testing.T) {
-	fs := afero.Afero{Fs: afero.NewMemMapFs()}
-	fs.MkdirAll(someDir, 0700)
-	fs.WriteFile(somePath, []byte("abcdfdfdfd"), 0700)
+	stats := &storeStats{
+		DiskSizeBytes: 10,
+	}
 
-	flag := cleanUpFileSizeCondition(someDir, 100, &fs)
+	flag := cleanUpFileSizeCondition(stats, 100)
 	assert.False(t, flag)
 }
 
@@ -122,11 +111,11 @@ func Test_doCleanup_true(t *testing.T) {
 	db := help_get_db(t)
 	tables := typed.NewTableList(db)
 
-	fs := afero.Afero{Fs: afero.NewMemMapFs()}
-	fs.MkdirAll(someDir, 0700)
-	fs.WriteFile(somePath, []byte("abcdfdfdfd"), 0700)
+	stats := &storeStats{
+		DiskSizeBytes: 10,
+	}
 
-	flag, err := doCleanup(tables, someDir, time.Hour, 2, &fs)
+	flag, err := doCleanup(tables, time.Hour, 2, stats)
 	assert.True(t, flag)
 	assert.Nil(t, err)
 }
@@ -135,11 +124,11 @@ func Test_doCleanup_false(t *testing.T) {
 	db := help_get_db(t)
 	tables := typed.NewTableList(db)
 
-	fs := afero.Afero{Fs: afero.NewMemMapFs()}
-	fs.MkdirAll(someDir, 0700)
-	fs.WriteFile(somePath, []byte("abcdfdfdfd"), 0700)
+	stats := &storeStats{
+		DiskSizeBytes: 10,
+	}
 
-	flag, err := doCleanup(tables, someDir, time.Hour, 1000, &fs)
+	flag, err := doCleanup(tables, time.Hour, 1000, stats)
 	assert.False(t, flag)
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
Problem: Disk usage in our cluster grew beyond the config limit, putting Sloop's GC into a tight loop of calling DropPrefix which was locking the DB.  For some reason Badger was simply not reclaiming disk space.

Solution: This PR does several things:

1. Tweaks the default settings for Badger, using LSMOnlyOptions() instead of DefaultOptions().  https://github.com/dgraph-io/badger/blob/master/options.go#L178 This moves most of the data volume from the vlog to the sst.
1. Remove the tight Sloop GC loop.  Always sleep between calls, even if there were keys removed.
1. Add a regular call to RunValueLogGC (with a config for frequency, discardRatio and loop).  https://godoc.org/github.com/dgraph-io/badger#DB.RunValueLogGC This should clean up old vlog files
1. Expose config options for MaxTableSize, KeepL0InMemory, VLogFileSize and VLogMaxEntries for fine tuning

I still need to give this some bake time in our cluster before I am confident it fixes the issues.  Because the recent badger v2 upgrade changed the data format, I need to wipe history and wait for it to exceed the limits to know for sure if all is good.