### PR TITLE
[providers/aws/sloop-to-eks.sh] Add 'profile' parameter

### DIFF
--- a/providers/aws/sloop-to-eks.sh
+++ b/providers/aws/sloop-to-eks.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-USAGE="Usage: ./sloop_to_eks.sh <cluster_name> [<region>]
+USAGE="Usage: ./sloop_to_eks.sh <cluster_name> [<region>] [<profile>]
 
 <cluster_name>: Provide EKS cluster to connect to.
       <region>: defaults to us-west-2.
+      <profile>: defaults to \`default\`
 "
 
 if [ $# -lt 1 ] || [ "$1" == "help" ]; then
@@ -14,5 +15,9 @@ REGION="us-west-2"
 if [ "$2" != "" ]; then
     REGION=$2
 fi
-aws eks --region $REGION update-kubeconfig --name $1
+PROFILE="default"
+if [ "$3" != "" ]; then
+    PROFILE=$3
+fi
+aws eks --region $REGION --profile $PROFILE update-kubeconfig --name $1
 docker run --rm -it -p 8080:8080 -v ~/.kube/:/kube/ -e KUBECONFIG=/kube/config -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN sloop


### PR DESCRIPTION
Add a `profile` parameter in order to switch between profiles without need to use `AWS_PROFILE` environment variable.