### PR TITLE
Fix for Sloop garbage collection when its not able to successfully decrease the size on disk

### DIFF
--- a/pkg/sloop/processing/eventcount.go
+++ b/pkg/sloop/processing/eventcount.go
@@ -52,7 +52,7 @@ func updateEventCountTable(
 	// This avoids filling in data that will go beyond the current time range
 
 	// Default truncate as computedLastTs -1 * PartitionDuration.
-	// Essentially only allowing events in 1 partition by default.
+	// Essentially only allowing events in 1 partition by default. This scenario will only be hit for first event on new sloop with no data.
 	truncateTs := computedLastTs.Add(-1 * untyped.GetPartitionDuration())
 
 	// If there is only one partition, use minPartitionStartTime to ensure we receive events

--- a/pkg/sloop/queries/timerange.go
+++ b/pkg/sloop/queries/timerange.go
@@ -13,7 +13,6 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/salesforce/sloop/pkg/sloop/store/typed"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped"
-	"github.com/salesforce/sloop/pkg/sloop/store/untyped/badgerwrap"
 	"net/url"
 	"strconv"
 	"time"
@@ -102,16 +101,9 @@ func computeTimeRangeInternal(params url.Values, endOfTime time.Time, maxLookBac
 // This bit of logic is needed for queries with a lookback to determine a good end time
 func getEndOfTime(tables typed.Tables) time.Time {
 	now := time.Now()
-	var maxPartition string
-	var ok bool
-	var minMaxError error
 
-	err := tables.Db().View(func(txn badgerwrap.Txn) error {
-		ok, _, maxPartition, minMaxError = tables.GetMinAndMaxPartition(txn)
-		return nil
-	})
-
-	if err != nil || minMaxError != nil || !ok {
+	ok, _, maxPartition, err := tables.GetMinAndMaxPartition()
+	if err != nil || !ok {
 		if err != nil {
 			glog.Errorf("Error getting MinAndMaxPartition: %v", err)
 		}

--- a/pkg/sloop/store/typed/eventcounttablegen.go
+++ b/pkg/sloop/store/typed/eventcounttablegen.go
@@ -132,6 +132,22 @@ func (t *ResourceEventCountsTable) GetMinMaxPartitions(txn badgerwrap.Txn) (bool
 	return true, minKey.PartitionId, maxKey.PartitionId
 }
 
+func (t *ResourceEventCountsTable) GetMinPartitions(txn badgerwrap.Txn) (bool, string) {
+	ok, minKeyStr := t.GetMinKey(txn)
+	if !ok {
+		return false, ""
+	}
+
+	minKey := &EventCountKey{}
+
+	err := minKey.Parse(minKeyStr)
+	if err != nil {
+		panic(fmt.Sprintf("invalid key in table: %v key: %q error: %v", t.tableName, minKeyStr, err))
+	}
+
+	return true, minKey.PartitionId
+}
+
 func (t *ResourceEventCountsTable) GetUniquePartitionList(txn badgerwrap.Txn) ([]string, error) {
 	resources := []string{}
 	ok, minPar, maxPar := t.GetMinMaxPartitions(txn)

--- a/pkg/sloop/store/typed/eventcounttablegen.go
+++ b/pkg/sloop/store/typed/eventcounttablegen.go
@@ -106,33 +106,33 @@ func (t *ResourceEventCountsTable) GetMaxKey(txn badgerwrap.Txn) (bool, string) 
 }
 
 func (t *ResourceEventCountsTable) GetMinMaxPartitions(txn badgerwrap.Txn) (bool, string, string) {
-	ok, minKeyStr := t.GetMinKey(txn)
-	if !ok {
+	minPartitionOk, minPar := t.GetMinPartition(txn)
+
+	if !minPartitionOk {
 		return false, "", ""
 	}
+
+	maxPartitionOk, maxPar := t.GetMaxPartition(txn)
+	return maxPartitionOk, minPar, maxPar
+}
+
+func (t *ResourceEventCountsTable) GetMaxPartition(txn badgerwrap.Txn) (bool, string) {
 	ok, maxKeyStr := t.GetMaxKey(txn)
 	if !ok {
-		// This should be impossible
-		return false, "", ""
+		return false, ""
 	}
 
-	minKey := &EventCountKey{}
 	maxKey := &EventCountKey{}
 
-	err := minKey.Parse(minKeyStr)
-	if err != nil {
-		panic(fmt.Sprintf("invalid key in table: %v key: %q error: %v", t.tableName, minKeyStr, err))
-	}
-
-	err = maxKey.Parse(maxKeyStr)
+	err := maxKey.Parse(maxKeyStr)
 	if err != nil {
 		panic(fmt.Sprintf("invalid key in table: %v key: %q error: %v", t.tableName, maxKeyStr, err))
 	}
 
-	return true, minKey.PartitionId, maxKey.PartitionId
+	return true, maxKey.PartitionId
 }
 
-func (t *ResourceEventCountsTable) GetMinPartitions(txn badgerwrap.Txn) (bool, string) {
+func (t *ResourceEventCountsTable) GetMinPartition(txn badgerwrap.Txn) (bool, string) {
 	ok, minKeyStr := t.GetMinKey(txn)
 	if !ok {
 		return false, ""

--- a/pkg/sloop/store/typed/resourcesummarytablegen.go
+++ b/pkg/sloop/store/typed/resourcesummarytablegen.go
@@ -106,33 +106,33 @@ func (t *ResourceSummaryTable) GetMaxKey(txn badgerwrap.Txn) (bool, string) {
 }
 
 func (t *ResourceSummaryTable) GetMinMaxPartitions(txn badgerwrap.Txn) (bool, string, string) {
-	ok, minKeyStr := t.GetMinKey(txn)
-	if !ok {
+	minPartitionOk, minPar := t.GetMinPartition(txn)
+
+	if !minPartitionOk {
 		return false, "", ""
 	}
+
+	maxPartitionOk, maxPar := t.GetMaxPartition(txn)
+	return maxPartitionOk, minPar, maxPar
+}
+
+func (t *ResourceSummaryTable) GetMaxPartition(txn badgerwrap.Txn) (bool, string) {
 	ok, maxKeyStr := t.GetMaxKey(txn)
 	if !ok {
-		// This should be impossible
-		return false, "", ""
+		return false, ""
 	}
 
-	minKey := &ResourceSummaryKey{}
 	maxKey := &ResourceSummaryKey{}
 
-	err := minKey.Parse(minKeyStr)
-	if err != nil {
-		panic(fmt.Sprintf("invalid key in table: %v key: %q error: %v", t.tableName, minKeyStr, err))
-	}
-
-	err = maxKey.Parse(maxKeyStr)
+	err := maxKey.Parse(maxKeyStr)
 	if err != nil {
 		panic(fmt.Sprintf("invalid key in table: %v key: %q error: %v", t.tableName, maxKeyStr, err))
 	}
 
-	return true, minKey.PartitionId, maxKey.PartitionId
+	return true, maxKey.PartitionId
 }
 
-func (t *ResourceSummaryTable) GetMinPartitions(txn badgerwrap.Txn) (bool, string) {
+func (t *ResourceSummaryTable) GetMinPartition(txn badgerwrap.Txn) (bool, string) {
 	ok, minKeyStr := t.GetMinKey(txn)
 	if !ok {
 		return false, ""

--- a/pkg/sloop/store/typed/resourcesummarytablegen.go
+++ b/pkg/sloop/store/typed/resourcesummarytablegen.go
@@ -132,6 +132,22 @@ func (t *ResourceSummaryTable) GetMinMaxPartitions(txn badgerwrap.Txn) (bool, st
 	return true, minKey.PartitionId, maxKey.PartitionId
 }
 
+func (t *ResourceSummaryTable) GetMinPartitions(txn badgerwrap.Txn) (bool, string) {
+	ok, minKeyStr := t.GetMinKey(txn)
+	if !ok {
+		return false, ""
+	}
+
+	minKey := &ResourceSummaryKey{}
+
+	err := minKey.Parse(minKeyStr)
+	if err != nil {
+		panic(fmt.Sprintf("invalid key in table: %v key: %q error: %v", t.tableName, minKeyStr, err))
+	}
+
+	return true, minKey.PartitionId
+}
+
 func (t *ResourceSummaryTable) GetUniquePartitionList(txn badgerwrap.Txn) ([]string, error) {
 	resources := []string{}
 	ok, minPar, maxPar := t.GetMinMaxPartitions(txn)

--- a/pkg/sloop/store/typed/tables.go
+++ b/pkg/sloop/store/typed/tables.go
@@ -19,16 +19,12 @@ type Tables interface {
 	WatchTable() *KubeWatchResultTable
 	WatchActivityTable() *WatchActivityTable
 	Db() badgerwrap.DB
-	GetMinPartition(txn badgerwrap.Txn) (bool, string, error)
-	GetMaxPartition(txn badgerwrap.Txn) (bool, string, error)
-	GetMinAndMaxPartition(txn badgerwrap.Txn) (bool, string, string, error)
+	GetMinAndMaxPartition() (bool, string, string, error)
 	GetTableNames() []string
 	GetTables() []interface{}
 }
 
-type PartitionsGetter interface {
-	GetMinPartition(badgerwrap.Txn) (bool, string)
-	GetMaxPartition(badgerwrap.Txn) (bool, string)
+type MinMaxPartitionsGetter interface {
 	GetMinMaxPartitions(badgerwrap.Txn) (bool, string, string)
 }
 
@@ -70,73 +66,32 @@ func (t *tablesImpl) Db() badgerwrap.DB {
 	return t.db
 }
 
-func (t *tablesImpl) GetMinAndMaxPartition(txn badgerwrap.Txn) (bool, string, string, error) {
+func (t *tablesImpl) GetMinAndMaxPartition() (bool, string, string, error) {
 	allPartitions := []string{}
+	err := t.db.View(func(txn badgerwrap.Txn) error {
+		for _, table := range t.GetTables() {
+			coerced, canCoerce := table.(MinMaxPartitionsGetter)
+			if !canCoerce {
+				glog.Errorf("Expected type to implement GetMinMaxPartitions but failed")
+				continue
+			}
+			ok, minPar, maxPar := coerced.GetMinMaxPartitions(txn)
+			if ok {
+				allPartitions = append(allPartitions, minPar, maxPar)
+			}
+		}
+		return nil
+	})
 
-	for _, table := range t.GetTables() {
-		coerced, canCoerce := table.(PartitionsGetter)
-		if !canCoerce {
-			glog.Errorf("Expected type to implement GetMinMaxPartitions but failed")
-			continue
-		}
-		ok, minPar, maxPar := coerced.GetMinMaxPartitions(txn)
-		if ok {
-			allPartitions = append(allPartitions, minPar, maxPar)
-		}
+	if err != nil {
+		return false, "", "", err
 	}
-
 	if len(allPartitions) == 0 {
 		return false, "", "", nil
 	}
 
 	sort.Strings(allPartitions)
 	return true, allPartitions[0], allPartitions[len(allPartitions)-1], nil
-}
-
-func (t *tablesImpl) GetMinPartition(txn badgerwrap.Txn) (bool, string, error) {
-	allPartitions := []string{}
-
-	for _, table := range t.GetTables() {
-		coerced, canCoerce := table.(PartitionsGetter)
-		if !canCoerce {
-			glog.Errorf("Expected type to implement GetMinPartition but failed")
-			continue
-		}
-		ok, minPar := coerced.GetMinPartition(txn)
-		if ok {
-			allPartitions = append(allPartitions, minPar)
-		}
-	}
-
-	if len(allPartitions) == 0 {
-		return false, "", nil
-	}
-
-	sort.Strings(allPartitions)
-	return true, allPartitions[0], nil
-}
-
-func (t *tablesImpl) GetMaxPartition(txn badgerwrap.Txn) (bool, string, error) {
-	allPartitions := []string{}
-
-	for _, table := range t.GetTables() {
-		coerced, canCoerce := table.(PartitionsGetter)
-		if !canCoerce {
-			glog.Errorf("Expected type to implement GetMaxPartition but failed")
-			continue
-		}
-		ok, maxPar := coerced.GetMaxPartition(txn)
-		if ok {
-			allPartitions = append(allPartitions, maxPar)
-		}
-	}
-
-	if len(allPartitions) == 0 {
-		return false, "", nil
-	}
-
-	sort.Strings(allPartitions)
-	return true, allPartitions[0], nil
 }
 
 func (t *tablesImpl) GetTableNames() []string {

--- a/pkg/sloop/store/typed/watchactivitytablegen.go
+++ b/pkg/sloop/store/typed/watchactivitytablegen.go
@@ -106,33 +106,33 @@ func (t *WatchActivityTable) GetMaxKey(txn badgerwrap.Txn) (bool, string) {
 }
 
 func (t *WatchActivityTable) GetMinMaxPartitions(txn badgerwrap.Txn) (bool, string, string) {
-	ok, minKeyStr := t.GetMinKey(txn)
-	if !ok {
+	minPartitionOk, minPar := t.GetMinPartition(txn)
+
+	if !minPartitionOk {
 		return false, "", ""
 	}
+
+	maxPartitionOk, maxPar := t.GetMaxPartition(txn)
+	return maxPartitionOk, minPar, maxPar
+}
+
+func (t *WatchActivityTable) GetMaxPartition(txn badgerwrap.Txn) (bool, string) {
 	ok, maxKeyStr := t.GetMaxKey(txn)
 	if !ok {
-		// This should be impossible
-		return false, "", ""
+		return false, ""
 	}
 
-	minKey := &WatchActivityKey{}
 	maxKey := &WatchActivityKey{}
 
-	err := minKey.Parse(minKeyStr)
-	if err != nil {
-		panic(fmt.Sprintf("invalid key in table: %v key: %q error: %v", t.tableName, minKeyStr, err))
-	}
-
-	err = maxKey.Parse(maxKeyStr)
+	err := maxKey.Parse(maxKeyStr)
 	if err != nil {
 		panic(fmt.Sprintf("invalid key in table: %v key: %q error: %v", t.tableName, maxKeyStr, err))
 	}
 
-	return true, minKey.PartitionId, maxKey.PartitionId
+	return true, maxKey.PartitionId
 }
 
-func (t *WatchActivityTable) GetMinPartitions(txn badgerwrap.Txn) (bool, string) {
+func (t *WatchActivityTable) GetMinPartition(txn badgerwrap.Txn) (bool, string) {
 	ok, minKeyStr := t.GetMinKey(txn)
 	if !ok {
 		return false, ""

--- a/pkg/sloop/store/typed/watchactivitytablegen.go
+++ b/pkg/sloop/store/typed/watchactivitytablegen.go
@@ -132,6 +132,22 @@ func (t *WatchActivityTable) GetMinMaxPartitions(txn badgerwrap.Txn) (bool, stri
 	return true, minKey.PartitionId, maxKey.PartitionId
 }
 
+func (t *WatchActivityTable) GetMinPartitions(txn badgerwrap.Txn) (bool, string) {
+	ok, minKeyStr := t.GetMinKey(txn)
+	if !ok {
+		return false, ""
+	}
+
+	minKey := &WatchActivityKey{}
+
+	err := minKey.Parse(minKeyStr)
+	if err != nil {
+		panic(fmt.Sprintf("invalid key in table: %v key: %q error: %v", t.tableName, minKeyStr, err))
+	}
+
+	return true, minKey.PartitionId
+}
+
 func (t *WatchActivityTable) GetUniquePartitionList(txn badgerwrap.Txn) ([]string, error) {
 	resources := []string{}
 	ok, minPar, maxPar := t.GetMinMaxPartitions(txn)

--- a/pkg/sloop/store/typed/watchtablegen.go
+++ b/pkg/sloop/store/typed/watchtablegen.go
@@ -132,6 +132,22 @@ func (t *KubeWatchResultTable) GetMinMaxPartitions(txn badgerwrap.Txn) (bool, st
 	return true, minKey.PartitionId, maxKey.PartitionId
 }
 
+func (t *KubeWatchResultTable) GetMinPartitions(txn badgerwrap.Txn) (bool, string) {
+	ok, minKeyStr := t.GetMinKey(txn)
+	if !ok {
+		return false, ""
+	}
+
+	minKey := &WatchTableKey{}
+
+	err := minKey.Parse(minKeyStr)
+	if err != nil {
+		panic(fmt.Sprintf("invalid key in table: %v key: %q error: %v", t.tableName, minKeyStr, err))
+	}
+
+	return true, minKey.PartitionId
+}
+
 func (t *KubeWatchResultTable) GetUniquePartitionList(txn badgerwrap.Txn) ([]string, error) {
 	resources := []string{}
 	ok, minPar, maxPar := t.GetMinMaxPartitions(txn)

--- a/pkg/sloop/store/typed/watchtablegen.go
+++ b/pkg/sloop/store/typed/watchtablegen.go
@@ -106,33 +106,33 @@ func (t *KubeWatchResultTable) GetMaxKey(txn badgerwrap.Txn) (bool, string) {
 }
 
 func (t *KubeWatchResultTable) GetMinMaxPartitions(txn badgerwrap.Txn) (bool, string, string) {
-	ok, minKeyStr := t.GetMinKey(txn)
-	if !ok {
+	minPartitionOk, minPar := t.GetMinPartition(txn)
+
+	if !minPartitionOk {
 		return false, "", ""
 	}
+
+	maxPartitionOk, maxPar := t.GetMaxPartition(txn)
+	return maxPartitionOk, minPar, maxPar
+}
+
+func (t *KubeWatchResultTable) GetMaxPartition(txn badgerwrap.Txn) (bool, string) {
 	ok, maxKeyStr := t.GetMaxKey(txn)
 	if !ok {
-		// This should be impossible
-		return false, "", ""
+		return false, ""
 	}
 
-	minKey := &WatchTableKey{}
 	maxKey := &WatchTableKey{}
 
-	err := minKey.Parse(minKeyStr)
-	if err != nil {
-		panic(fmt.Sprintf("invalid key in table: %v key: %q error: %v", t.tableName, minKeyStr, err))
-	}
-
-	err = maxKey.Parse(maxKeyStr)
+	err := maxKey.Parse(maxKeyStr)
 	if err != nil {
 		panic(fmt.Sprintf("invalid key in table: %v key: %q error: %v", t.tableName, maxKeyStr, err))
 	}
 
-	return true, minKey.PartitionId, maxKey.PartitionId
+	return true, maxKey.PartitionId
 }
 
-func (t *KubeWatchResultTable) GetMinPartitions(txn badgerwrap.Txn) (bool, string) {
+func (t *KubeWatchResultTable) GetMinPartition(txn badgerwrap.Txn) (bool, string) {
 	ok, minKeyStr := t.GetMinKey(txn)
 	if !ok {
 		return false, ""

--- a/pkg/sloop/storemanager/stats.go
+++ b/pkg/sloop/storemanager/stats.go
@@ -23,12 +23,12 @@ var (
 	metricBadgerLsmSizeMb            = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_badger_lsmsizemb"})
 	metricBadgerVLogFileCount        = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_badger_vlogfilecount"})
 	metricBadgerVLogSizeMb           = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_badger_vlogsizemb"})
-	metricCleanedStoreSizeOnDiskMb   = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_garbage_collected_sizeondiskmb"})
-	metricCleanedBadgerKeys          = promauto.NewGaugeVec(prometheus.GaugeOpts{Name: "sloop_garbage_collected_badger_keys"}, []string{"level"})
-	metricCleanedBadgerLsmFileCount  = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_garbage_collected_badger_lsmfilecount"})
-	metricCleanedBadgerLsmSizeMb     = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_garbage_collected_badger_lsmsizemb"})
-	metricCleanedBadgerVLogFileCount = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_garbage_collected_badger_vlogfilecount"})
-	metricCleanedBadgerVLogSizeMb    = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_garbage_collected_badger_vlogsizemb"})
+	metricCleanedStoreSizeOnDiskMb   = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_delta_aftergc_sizeondiskmb"})
+	metricCleanedBadgerKeys          = promauto.NewGaugeVec(prometheus.GaugeOpts{Name: "sloop_delta_aftergc_badger_keys"}, []string{"level"})
+	metricCleanedBadgerLsmFileCount  = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_delta_aftergc_badger_lsmfilecount"})
+	metricCleanedBadgerLsmSizeMb     = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_delta_aftergc_badger_lsmsizemb"})
+	metricCleanedBadgerVLogFileCount = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_delta_aftergc_badger_vlogfilecount"})
+	metricCleanedBadgerVLogSizeMb    = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_delta_aftergc_badger_vlogsizemb"})
 )
 
 type storeStats struct {
@@ -126,7 +126,6 @@ func getDeltaStats(beforeStats *storeStats, afterStats *storeStats) *storeStats 
 		metricCleanedBadgerKeys.WithLabelValues(fmt.Sprintf("%v", k)).Set(float64(v) - float64(afterStats.LevelToKeyCount[k]))
 	}
 	ret.DiskSizeBytes = beforeStats.DiskSizeBytes - afterStats.DiskSizeBytes
-	fmt.Printf("before %6d and after %6d and delta %6d", beforeStats.DiskSizeBytes, afterStats.DiskSizeBytes, ret.DiskSizeBytes)
 	ret.DiskLsmFileCount = beforeStats.DiskLsmFileCount - afterStats.DiskLsmFileCount
 	ret.DiskLsmBytes = beforeStats.DiskLsmBytes - afterStats.DiskLsmBytes
 	ret.DiskVlogFileCount = beforeStats.DiskVlogFileCount - afterStats.DiskVlogFileCount

--- a/pkg/sloop/storemanager/stats.go
+++ b/pkg/sloop/storemanager/stats.go
@@ -16,21 +16,27 @@ const vlogExt = ".vlog" // value log data
 const sstExt = ".sst"   // LSM data
 
 var (
-	metricStoreSizeOnDiskMb   = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_store_sizeondiskmb"})
-	metricBadgerKeys          = promauto.NewGaugeVec(prometheus.GaugeOpts{Name: "sloop_badger_keys"}, []string{"level"})
-	metricBadgerTables        = promauto.NewGaugeVec(prometheus.GaugeOpts{Name: "sloop_badger_tables"}, []string{"level"})
-	metricBadgerLsmFileCount  = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_badger_lsmfilecount"})
-	metricBadgerLsmSizeMb     = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_badger_lsmsizemb"})
-	metricBadgerVLogFileCount = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_badger_vlogfilecount"})
-	metricBadgerVLogSizeMb    = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_badger_vlogsizemb"})
+	metricStoreSizeOnDiskMb          = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_store_sizeondiskmb"})
+	metricBadgerKeys                 = promauto.NewGaugeVec(prometheus.GaugeOpts{Name: "sloop_badger_keys"}, []string{"level"})
+	metricBadgerTables               = promauto.NewGaugeVec(prometheus.GaugeOpts{Name: "sloop_badger_tables"}, []string{"level"})
+	metricBadgerLsmFileCount         = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_badger_lsmfilecount"})
+	metricBadgerLsmSizeMb            = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_badger_lsmsizemb"})
+	metricBadgerVLogFileCount        = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_badger_vlogfilecount"})
+	metricBadgerVLogSizeMb           = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_badger_vlogsizemb"})
+	metricCleanedStoreSizeOnDiskMb   = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_garbage_collected_sizeondiskmb"})
+	metricCleanedBadgerKeys          = promauto.NewGaugeVec(prometheus.GaugeOpts{Name: "sloop_garbage_collected_badger_keys"}, []string{"level"})
+	metricCleanedBadgerLsmFileCount  = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_garbage_collected_badger_lsmfilecount"})
+	metricCleanedBadgerLsmSizeMb     = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_garbage_collected_badger_lsmsizemb"})
+	metricCleanedBadgerVLogFileCount = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_garbage_collected_badger_vlogfilecount"})
+	metricCleanedBadgerVLogSizeMb    = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_garbage_collected_badger_vlogsizemb"})
 )
 
 type storeStats struct {
 	timestamp         time.Time
-	DiskSizeBytes     uint64
-	DiskLsmBytes      uint64
+	DiskSizeBytes     int64
+	DiskLsmBytes      int64
 	DiskLsmFileCount  int
-	DiskVlogBytes     uint64
+	DiskVlogBytes     int64
 	DiskVlogFileCount int
 	LevelToKeyCount   map[int]uint64
 	LevelToTableCount map[int]int
@@ -47,11 +53,11 @@ func generateStats(storeRoot string, db badgerwrap.DB, fs *afero.Afero) *storeSt
 		// Swallowing on purpose as we still want the other stats
 		glog.Errorf("Failed to check storage size on disk: %v", err)
 	}
-	ret.DiskSizeBytes = totalSizeBytes
+	ret.DiskSizeBytes = int64(totalSizeBytes)
 	ret.DiskLsmFileCount = extFileCount[sstExt]
-	ret.DiskLsmBytes = extByteCount[sstExt]
+	ret.DiskLsmBytes = int64(extByteCount[sstExt])
 	ret.DiskVlogFileCount = extFileCount[vlogExt]
-	ret.DiskVlogBytes = extByteCount[vlogExt]
+	ret.DiskVlogBytes = int64(extByteCount[vlogExt])
 
 	tables := db.Tables(true)
 	for _, table := range tables {
@@ -98,4 +104,33 @@ func emitMetrics(stats *storeStats) {
 	metricBadgerLsmSizeMb.Set(float64(stats.DiskLsmBytes / 1024 / 1024))
 	metricBadgerVLogFileCount.Set(float64(stats.DiskVlogFileCount))
 	metricBadgerVLogSizeMb.Set(float64(stats.DiskVlogBytes / 1024 / 1024))
+}
+
+func emitGCMetrics(stats *storeStats) {
+	metricCleanedStoreSizeOnDiskMb.Set(float64(stats.DiskSizeBytes / 1024 / 1024))
+	for k, v := range stats.LevelToKeyCount {
+		metricCleanedBadgerKeys.WithLabelValues(fmt.Sprintf("%v", k)).Set(float64(v))
+	}
+	metricCleanedBadgerLsmFileCount.Set(float64(stats.DiskLsmFileCount))
+	metricCleanedBadgerLsmSizeMb.Set(float64(stats.DiskLsmBytes / 1024 / 1024))
+	metricCleanedBadgerVLogFileCount.Set(float64(stats.DiskVlogFileCount))
+	metricCleanedBadgerVLogSizeMb.Set(float64(stats.DiskVlogBytes / 1024 / 1024))
+}
+
+func getDeltaStats(beforeStats *storeStats, afterStats *storeStats) *storeStats {
+	ret := &storeStats{}
+	ret.LevelToKeyCount = make(map[int]uint64)
+	ret.LevelToTableCount = make(map[int]int)
+
+	for k, v := range beforeStats.LevelToKeyCount {
+		metricCleanedBadgerKeys.WithLabelValues(fmt.Sprintf("%v", k)).Set(float64(v) - float64(afterStats.LevelToKeyCount[k]))
+	}
+	ret.DiskSizeBytes = beforeStats.DiskSizeBytes - afterStats.DiskSizeBytes
+	fmt.Printf("before %6d and after %6d and delta %6d", beforeStats.DiskSizeBytes, afterStats.DiskSizeBytes, ret.DiskSizeBytes)
+	ret.DiskLsmFileCount = beforeStats.DiskLsmFileCount - afterStats.DiskLsmFileCount
+	ret.DiskLsmBytes = beforeStats.DiskLsmBytes - afterStats.DiskLsmBytes
+	ret.DiskVlogFileCount = beforeStats.DiskVlogFileCount - afterStats.DiskVlogFileCount
+	ret.DiskVlogBytes = beforeStats.DiskVlogBytes - afterStats.DiskVlogBytes
+
+	return ret
 }

--- a/pkg/sloop/storemanager/storemanager.go
+++ b/pkg/sloop/storemanager/storemanager.go
@@ -83,7 +83,9 @@ func (sm *StoreManager) gcLoop() {
 			glog.Infof("Store manager main loop exiting")
 			return
 		}
-		sm.refreshStats()
+
+		var beforeGCStats = sm.refreshStats()
+
 		metricGcRunCount.Inc()
 		before := time.Now()
 		metricGcRunning.Set(1)
@@ -96,6 +98,10 @@ func (sm *StoreManager) gcLoop() {
 		}
 		metricGcLatency.Set(time.Since(before).Seconds())
 		glog.Infof("GC finished in %v with return %q.  Next run in %v", time.Since(before), err, sm.config.Freq)
+
+		var afterGCEnds = sm.refreshStats()
+		var deltaStats = getDeltaStats(beforeGCStats, afterGCEnds)
+		emitGCMetrics(deltaStats)
 		sm.sleeper.Sleep(sm.config.Freq)
 	}
 }
@@ -111,7 +117,8 @@ func (sm *StoreManager) vlogGcLoop() {
 			glog.Infof("ValueLogGC loop exiting")
 			return
 		}
-		sm.refreshStats()
+
+		var beforeGCStats = sm.refreshStats()
 		for {
 			before := time.Now()
 			metricValueLogGcRunning.Set(1)
@@ -123,6 +130,9 @@ func (sm *StoreManager) vlogGcLoop() {
 			if err != nil {
 				break
 			}
+			var afterGCEnds = sm.refreshStats()
+			var deltaStats = getDeltaStats(beforeGCStats, afterGCEnds)
+			emitGCMetrics(deltaStats)
 		}
 		sm.sleeper.Sleep(sm.config.BadgerVLogGCFreq)
 	}
@@ -137,14 +147,15 @@ func (sm *StoreManager) Shutdown() {
 	sm.wg.Wait()
 }
 
-func (sm *StoreManager) refreshStats() {
+func (sm *StoreManager) refreshStats() *storeStats {
 	// On startup we have 2 routines trying to do this at the same time
 	// If we have fresh results its good enough
 	if sm.stats != nil && time.Since(sm.stats.timestamp) < time.Second {
-		return
+		return sm.stats
 	}
-	sm.stats = generateStats(sm.config.StoreRoot, sm.tables.Db(), sm.fs)
+	sm.stats =  generateStats(sm.config.StoreRoot, sm.tables.Db(), sm.fs)
 	emitMetrics(sm.stats)
+	return sm.stats
 }
 
 func doCleanup(tables typed.Tables, timeLimit time.Duration, sizeLimitBytes int, stats *storeStats) (bool, error) {
@@ -208,8 +219,7 @@ func cleanUpTimeCondition(minPartition string, maxPartition string, timeLimit ti
 }
 
 func cleanUpFileSizeCondition(stats *storeStats, sizeLimitBytes int) bool {
-
-	if stats.DiskSizeBytes > uint64(sizeLimitBytes) {
+	if stats.DiskSizeBytes > int64(sizeLimitBytes) {
 		glog.Infof("Start cleaning up because current file size: %v exceeds file size: %v", stats.DiskSizeBytes, sizeLimitBytes)
 		return true
 	}

--- a/pkg/sloop/storemanager/storemanager_test.go
+++ b/pkg/sloop/storemanager/storemanager_test.go
@@ -75,10 +75,12 @@ func help_get_db(t *testing.T) badgerwrap.DB {
 	key1 := typed.NewWatchTableKey(partitionId, someKind+"a", someNamespace, someName, someTs).String()
 	key2 := typed.NewResourceSummaryKey(someTs, someKind+"b", someNamespace, someName, someUid).String()
 	key3 := typed.NewEventCountKey(someTs, someKind+"c", someNamespace, someName, someUid).String()
+	key4 := typed.NewWatchActivityKey(untyped.GetPartitionId(someTs), someKind+"d", someNamespace, someName, someUid).String()
 
 	wtval := &typed.KubeWatchResult{Kind: someKind}
 	rtval := &typed.ResourceSummary{DeletedAtEnd: false}
 	ecVal := &typed.ResourceEventCounts{XXX_sizecache: int32(0)}
+	waVal := &typed.WatchActivity{XXX_sizecache: int32((0))}
 
 	db, err := (&badgerwrap.MockFactory{}).Open(badger.DefaultOptions(""))
 	assert.Nil(t, err)
@@ -87,6 +89,7 @@ func help_get_db(t *testing.T) badgerwrap.DB {
 	wt := typed.OpenKubeWatchResultTable()
 	rt := typed.OpenResourceSummaryTable()
 	ec := typed.OpenResourceEventCountsTable()
+	wa := typed.OpenWatchActivityTable()
 	err = db.Update(func(txn badgerwrap.Txn) error {
 		txerr := wt.Set(txn, key1, wtval)
 		if txerr != nil {
@@ -97,6 +100,10 @@ func help_get_db(t *testing.T) badgerwrap.DB {
 			return txerr
 		}
 		txerr = ec.Set(txn, key3, ecVal)
+		if txerr != nil {
+			return txerr
+		}
+		txerr = wa.Set(txn, key4, waVal)
 		if txerr != nil {
 			return txerr
 		}

--- a/pkg/sloop/webserver/weblogging.go
+++ b/pkg/sloop/webserver/weblogging.go
@@ -45,6 +45,8 @@ func glogWrapper(handler http.Handler) http.Handler {
 		before := time.Now()
 		handler.ServeHTTP(w, r)
 		requestID := getRequestId(r.Context())
-		glog.Infof("reqId: %v http url: %v took: %v remote: %v useragent: %v", requestID, r.URL, time.Since(before), r.RemoteAddr, r.UserAgent())
+		var timeTaken = time.Since(before)
+		metricWebServerRequestLatency.Set(timeTaken.Seconds())
+		glog.Infof("reqId: %v http url: %v took: %v remote: %v useragent: %v", requestID, r.URL, timeTaken, r.RemoteAddr, r.UserAgent())
 	})
 }

--- a/pkg/sloop/webserver/webserver.go
+++ b/pkg/sloop/webserver/webserver.go
@@ -61,7 +61,8 @@ type WebConfig struct {
 }
 
 var (
-	metricWebServerRequestCount = promauto.NewCounter(prometheus.CounterOpts{Name: "sloop_webserver_request_count"})
+	metricWebServerRequestCount   = promauto.NewCounter(prometheus.CounterOpts{Name: "sloop_webserver_request_count"})
+	metricWebServerRequestLatency = promauto.NewGauge(prometheus.GaugeOpts{Name: "sloop_webserver_request_latency"})
 )
 
 // This is not going to change and we don't want to pass it to every function


### PR DESCRIPTION
Problem: Disk usage in our cluster grew way beyond the config limit resulting the application to be OOM killed. There were a couple of issues identified and fixed as follows:

1. Event count table data (although it is the smallest table in terms of number of keys and size) was getting added beyond the max look back time.

```
Before Event Count data is added:    MaxLookBack|----- Count: 50 ---|
                                                                   
After Event Count data is added :      *****MaxLookBack|----- Count: 50 ---|
(new data is shown using *) 
```

2. The sprinkling of event count data was using max look back as a boundary resulting in small partitions containing very less event count data spread all across till look back time.

```
Before Event Count data is added:     MaxLookBack|        |MinPartition -----|
                                                                   
After Event Count data is added:      MaxLookBack|********|MinPartition -----|
```

3. Garbage collection was never called for watch activity table.

Apart from these this PR also adds some new metrics.