### PR TITLE
Faster upload speed of payloads

### DIFF
--- a/pkg/sloop/webfiles/resource.html
+++ b/pkg/sloop/webfiles/resource.html
@@ -44,14 +44,14 @@ For full license text, see LICENSE.txt file in the repo root or https://opensour
         <h2>Viewing range {{.ClickTime}} +/- {{.PlusMinusTime}}</h2>
         <table id="resource_event_table">
             <tr>
-                <th>Left Payload</th>
-                <th>Right Payload</th>
+                <th @click="sort('leftPayload')">Left Payload</th>
+                <th @click="sort('rightPayload')">Right Payload</th>
                 <th>Payload Link</th>
                 <th @click="sort('payloadTime')">PayloadTime &#x21C5</th>
             </tr>
             <tr v-for="res in sortedResPayloads">
-                <td><input type="radio" :value="res.payload" :id="res.payloadKey" v-model="leftPayload" v-on:change="doDiff();"/></td>
-                <td><input type="radio" :value="res.payload" :id="res.payloadKey" v-model="rightPayload" v-on:change="doDiff();"/></td>
+                <td>${res.leftPayload}<input type="radio" :value="res.payload" :id="res.payloadKey" v-model="leftPayload" v-on:change="doDiff();"/></td>
+                <td>${res.rightPayload}<input type="radio" :value="res.payload" :id="res.payloadKey" v-model="rightPayload" v-on:change="doDiff();"/></td>
                 <td><a :href ="res.origValue | get_payload_url" target="_blank">Details</a></td>
                 <td>${ res.payloadTime | get_formatted_time}</td>
             </tr>
@@ -130,6 +130,8 @@ For full license text, see LICENSE.txt file in the repo root or https://opensour
                                 payloadTime: val.payloadTime,
                                 payloadKey: val.payloadKey,
                                 payload: val.payload,
+                                leftPayload:'',
+                                rightPayload:'',
                                 origValue: val,
                             };
                         });


### PR DESCRIPTION
UI issue was causing payloads to take minutes to load. Fixed it to show payloads for selected event faster @sana-jawad  @mallow111 
before-
https://user-images.githubusercontent.com/70977265/94944283-03848c80-04a7-11eb-9df6-8d7dbcf51373.png
after-
https://user-images.githubusercontent.com/70977265/94944228-f1a2e980-04a6-11eb-97cf-74fec9a5c477.png