### PR TITLE
Rafabios feature/ingress-and-svc-type

### DIFF
--- a/helm/sloop/templates/ingress.yaml
+++ b/helm/sloop/templates/ingress.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+  {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.name }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+  name: {{ .Values.name }}
+  #namespace: {{ .Values.namespace }}
+spec:
+  rules:
+  - host: {{ .Values.ingress.host }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ .Values.name }}
+          servicePort: {{ .Values.service.port }}
+        path: /
+{{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}

--- a/helm/sloop/templates/ingress.yaml
+++ b/helm/sloop/templates/ingress.yaml
@@ -12,7 +12,6 @@ metadata:
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
   name: {{ .Values.name }}
-  #namespace: {{ .Values.namespace }}
 spec:
   rules:
   - host: {{ .Values.ingress.host }}

--- a/helm/sloop/templates/service.yaml
+++ b/helm/sloop/templates/service.yaml
@@ -15,3 +15,4 @@ spec:
     targetPort: {{ .Values.service.targetPort }}
   selector:
     app.kubernetes.io/name: {{ .Values.name }}
+  type: {{ .Values.service.type }}

--- a/helm/sloop/values.yaml
+++ b/helm/sloop/values.yaml
@@ -15,6 +15,7 @@ resources: {}
 service:
   port: 80
   targetPort: 8080
+  type: ClusterIP
 ## Configure extra options for liveness and readiness probes
 livenessProbe:
   enabled: true
@@ -30,3 +31,8 @@ readinessProbe:
   timeoutSeconds: 5
   failureThreshold: 3
   successThreshold: 1
+ingress:
+ enabled: false
+ host: sloop.example.com
+ annotations: {}
+ tls: {}


### PR DESCRIPTION
Added ingress templating suppot: is possible to use nginx, kong, traefik and so on as a ingress controller;

Added service type, so users can choose between ClusterIP, NodePort and LoadBalancer;