### PR TITLE
Add User Input End Time as a Parameter

### DIFF
--- a/pkg/sloop/queries/timerange.go
+++ b/pkg/sloop/queries/timerange.go
@@ -43,9 +43,7 @@ func computeTimeRange(params url.Values, tables typed.Tables, maxLookBack time.D
 // Compare result of function `getEndOfTime` and user defined end time,
 // return the earlier one
 func computeActualEndTime(userInputEndTime string, endOfTime time.Time) time.Time {
-	var userDefinedEndOfTime time.Time
-	var err error
-	userDefinedEndOfTime, err = parseUnixTimeString(userInputEndTime)
+	userDefinedEndOfTime, err := parseUnixTimeString(userInputEndTime)
 	if err != nil {
 		glog.Errorf("Invalid EndTimeParam input: %v.  err: %v", userInputEndTime, err)
 		return endOfTime

--- a/pkg/sloop/queries/timerange_test.go
+++ b/pkg/sloop/queries/timerange_test.go
@@ -87,6 +87,10 @@ func Test_computeActualEndTime(t *testing.T) {
 	result = computeActualEndTime(userInputEndTime, endOfTime)
 	assert.Equal(t, result, someQueryEndTs)
 
+	// endOfTIme is the same as userInput
+	result = computeActualEndTime(userInputEndTime, someQueryEndTs)
+	assert.Equal(t, result, someQueryEndTs)
+
 	// invalid userInput
 	result = computeActualEndTime("", endOfTime)
 	assert.Equal(t, result, endOfTime)

--- a/pkg/sloop/queries/timerange_test.go
+++ b/pkg/sloop/queries/timerange_test.go
@@ -73,6 +73,25 @@ func Test_timeRangeTable(t *testing.T) {
 	}
 }
 
+func Test_computeActualEndTime(t *testing.T) {
+	var userInputEndTime string
+	var endOfTime time.Time
+	var result time.Time
+	userInputEndTime = fmt.Sprintf("%v", someQueryEndTs.UTC().Unix())
+	// endOfTIme is before userInput
+	result = computeActualEndTime(userInputEndTime, endOfTime)
+	assert.Equal(t, result, endOfTime)
+
+	// endOfTIme is after userInput
+	endOfTime = someQueryEndTs.Add(time.Hour*2)
+	result = computeActualEndTime(userInputEndTime, endOfTime)
+	assert.Equal(t, result, someQueryEndTs)
+
+	// invalid userInput
+	result = computeActualEndTime("", endOfTime)
+	assert.Equal(t, result, endOfTime)
+}
+
 func Test_timeFilterResSumValue_OutsideRangeDrop(t *testing.T) {
 	resVal := typed.ResourceSummary{}
 	resVal.CreateTime, _ = ptypes.TimestampProto(rightBeforeStartTs)


### PR DESCRIPTION
Problem:
Custom Time Search enables user to select an end time, right now we have end time defaulted to `now`. Need to add a configurable end time parameter and pass it to the existing query.

Solution:
Add a new parameter `userInputEndTime`, compared to the output of function `getEndOfTime`, the earlier one will be the actual end time.