### PR TITLE
Add User Input End Time

### DIFF
--- a/pkg/sloop/queries/timerange.go
+++ b/pkg/sloop/queries/timerange.go
@@ -62,18 +62,18 @@ func computeTimeRangeInternal(params url.Values, endOfTime time.Time, maxLookBac
 		}
 	}
 
+	// always use customer input as computedEnd
+	computedStart, computedEnd, err = getTimeRangeFromStartEnd(startTimeVal, endTimeVal)
+	if err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+
 	if lookBackVal != "" {
-		computedEnd = endOfTime
 		lookbackRange, err := getDurationFromLookback(lookBackVal)
 		if err != nil {
 			return time.Time{}, time.Time{}, err
 		}
 		computedStart = computedEnd.Add(-1 * lookbackRange)
-	} else {
-		computedStart, computedEnd, err = getTimeRangeFromStartEnd(startTimeVal, endTimeVal)
-		if err != nil {
-			return time.Time{}, time.Time{}, err
-		}
 	}
 
 	// If the time range ends beyond endOfTime shift it back

--- a/pkg/sloop/queries/timerange_test.go
+++ b/pkg/sloop/queries/timerange_test.go
@@ -33,11 +33,15 @@ func Test_timeRangeTable(t *testing.T) {
 		expectedEnd   time.Time
 	}{
 		// Valid Cases
+		{"2h", "", fmt.Sprintf("%v", someQueryEndTs.UTC().Unix()), false, someQueryEndTs.Add(-2 * time.Hour), someQueryEndTs},
+		{"1h", "", "", false, someQueryEndTs.Add(-1 * time.Hour), someQueryEndTs},
+		{"0h", "", "", false, someQueryEndTs.Add(-1 * minLookback), someQueryEndTs},
+		{"1000h", "", "", false, someQueryEndTs.Add(-1 * someMaxLookBack), someQueryEndTs},
 		{"", fmt.Sprintf("%v", someQueryEndTs.Add(time.Minute*-45).UTC().Unix()), fmt.Sprintf("%v", someQueryEndTs.Add(time.Minute*-15).UTC().Unix()), false, someQueryEndTs.Add(time.Minute * -45), someQueryEndTs.Add(time.Minute * -15)},
-		{"", fmt.Sprintf("%v", someQueryEndTs.Add(time.Minute*-35).UTC().Unix()), fmt.Sprintf("%v", someQueryEndTs.Add(time.Minute*-5).UTC().Unix()), false, someQueryEndTs.Add(time.Minute * -35), someQueryEndTs.Add(time.Minute * -5)},
 		{"", fmt.Sprintf("%v", someQueryEndTs.Add(time.Minute*-30).UTC().Unix()), fmt.Sprintf("%v", someQueryEndTs.Add(time.Minute*5).UTC().Unix()), false, someQueryEndTs.Add(time.Minute * -35), someQueryEndTs},
 
 		// Too short, gets adjusted
+		{"0h", "", "", false, someQueryEndTs.Add(-1 * minLookback), someQueryEndTs},
 		{"", fmt.Sprintf("%v", someQueryEndTs.UTC().Unix()), fmt.Sprintf("%v", someQueryEndTs.UTC().Unix()), false, someQueryEndTs.Add(-1 * minLookback), someQueryEndTs},
 		// Too long, gets adjusted
 		{"", fmt.Sprintf("%v", someQueryEndTs.Add(-1000*time.Hour).UTC().Unix()), fmt.Sprintf("%v", someQueryEndTs.UTC().Unix()), false, someQueryEndTs.Add(-1 * someMaxLookBack), someQueryEndTs},
@@ -45,9 +49,6 @@ func Test_timeRangeTable(t *testing.T) {
 		{"", fmt.Sprintf("%v", someQueryEndTs.Add(time.Minute*-15).UTC().Unix()), fmt.Sprintf("%v", someQueryEndTs.Add(time.Minute*15).UTC().Unix()), false, someQueryEndTs.Add(time.Minute * -30), someQueryEndTs},
 
 		// Missing or too many inputs
-		{"1h", "", "", true, someQueryEndTs.Add(-1 * time.Hour), someQueryEndTs},
-		{"0h", "", "", true, someQueryEndTs.Add(-1 * minLookback), someQueryEndTs},
-		{"1000h", "", "", true, someQueryEndTs.Add(-1 * someMaxLookBack), someQueryEndTs},
 		{"", "", "", true, time.Time{}, time.Time{}},
 		{"", "123", "", true, time.Time{}, time.Time{}},
 		{"", "", "123", true, time.Time{}, time.Time{}},

--- a/pkg/sloop/queries/timerange_test.go
+++ b/pkg/sloop/queries/timerange_test.go
@@ -60,8 +60,7 @@ func Test_timeRangeTable(t *testing.T) {
 		{"", "123", "abc", true, time.Time{}, time.Time{}},
 	}
 	for i, thisRange := range rangeTests {
-		fmt.Print(i)
-		t.Run(fmt.Sprintf("%+v", thisRange), func(t *testing.T) {
+		t.Run(fmt.Sprintf("Test id: %v, thisRange: %v", i, thisRange), func(t *testing.T){
 			paramMap := make(map[string][]string)
 			paramMap[LookbackParam] = []string{thisRange.lookbackStr}
 			paramMap[StartTimeParam] = []string{thisRange.startStr}

--- a/pkg/sloop/queries/timerange_test.go
+++ b/pkg/sloop/queries/timerange_test.go
@@ -33,19 +33,21 @@ func Test_timeRangeTable(t *testing.T) {
 		expectedEnd   time.Time
 	}{
 		// Valid Cases
-		{"1h", "", "", false, someQueryEndTs.Add(-1 * time.Hour), someQueryEndTs},
 		{"", fmt.Sprintf("%v", someQueryEndTs.Add(time.Minute*-45).UTC().Unix()), fmt.Sprintf("%v", someQueryEndTs.Add(time.Minute*-15).UTC().Unix()), false, someQueryEndTs.Add(time.Minute * -45), someQueryEndTs.Add(time.Minute * -15)},
+		{"", fmt.Sprintf("%v", someQueryEndTs.Add(time.Minute*-35).UTC().Unix()), fmt.Sprintf("%v", someQueryEndTs.Add(time.Minute*-5).UTC().Unix()), false, someQueryEndTs.Add(time.Minute * -35), someQueryEndTs.Add(time.Minute * -5)},
+		{"", fmt.Sprintf("%v", someQueryEndTs.Add(time.Minute*-30).UTC().Unix()), fmt.Sprintf("%v", someQueryEndTs.Add(time.Minute*5).UTC().Unix()), false, someQueryEndTs.Add(time.Minute * -35), someQueryEndTs},
 
 		// Too short, gets adjusted
-		{"0h", "", "", false, someQueryEndTs.Add(-1 * minLookback), someQueryEndTs},
 		{"", fmt.Sprintf("%v", someQueryEndTs.UTC().Unix()), fmt.Sprintf("%v", someQueryEndTs.UTC().Unix()), false, someQueryEndTs.Add(-1 * minLookback), someQueryEndTs},
 		// Too long, gets adjusted
-		{"1000h", "", "", false, someQueryEndTs.Add(-1 * someMaxLookBack), someQueryEndTs},
 		{"", fmt.Sprintf("%v", someQueryEndTs.Add(-1000*time.Hour).UTC().Unix()), fmt.Sprintf("%v", someQueryEndTs.UTC().Unix()), false, someQueryEndTs.Add(-1 * someMaxLookBack), someQueryEndTs},
 		// Ends in the future
 		{"", fmt.Sprintf("%v", someQueryEndTs.Add(time.Minute*-15).UTC().Unix()), fmt.Sprintf("%v", someQueryEndTs.Add(time.Minute*15).UTC().Unix()), false, someQueryEndTs.Add(time.Minute * -30), someQueryEndTs},
 
 		// Missing or too many inputs
+		{"1h", "", "", true, someQueryEndTs.Add(-1 * time.Hour), someQueryEndTs},
+		{"0h", "", "", true, someQueryEndTs.Add(-1 * minLookback), someQueryEndTs},
+		{"1000h", "", "", true, someQueryEndTs.Add(-1 * someMaxLookBack), someQueryEndTs},
 		{"", "", "", true, time.Time{}, time.Time{}},
 		{"", "123", "", true, time.Time{}, time.Time{}},
 		{"", "", "123", true, time.Time{}, time.Time{}},
@@ -55,7 +57,8 @@ func Test_timeRangeTable(t *testing.T) {
 		{"", "abc", "123", true, time.Time{}, time.Time{}},
 		{"", "123", "abc", true, time.Time{}, time.Time{}},
 	}
-	for _, thisRange := range rangeTests {
+	for i, thisRange := range rangeTests {
+		fmt.Print(i)
 		t.Run(fmt.Sprintf("%+v", thisRange), func(t *testing.T) {
 			paramMap := make(map[string][]string)
 			paramMap[LookbackParam] = []string{thisRange.lookbackStr}

--- a/pkg/sloop/queries/timerange_test.go
+++ b/pkg/sloop/queries/timerange_test.go
@@ -60,7 +60,7 @@ func Test_timeRangeTable(t *testing.T) {
 		{"", "123", "abc", true, time.Time{}, time.Time{}},
 	}
 	for i, thisRange := range rangeTests {
-		t.Run(fmt.Sprintf("Test id: %v, thisRange: %v", i, thisRange), func(t *testing.T){
+		t.Run(fmt.Sprintf("Test id: %v, thisRange: %+v", i, thisRange), func(t *testing.T){
 			paramMap := make(map[string][]string)
 			paramMap[LookbackParam] = []string{thisRange.lookbackStr}
 			paramMap[StartTimeParam] = []string{thisRange.startStr}

--- a/pkg/sloop/queries/timerange_test.go
+++ b/pkg/sloop/queries/timerange_test.go
@@ -44,6 +44,7 @@ func Test_timeRangeTable(t *testing.T) {
 		{"0h", "", "", false, someQueryEndTs.Add(-1 * minLookback), someQueryEndTs},
 		{"", fmt.Sprintf("%v", someQueryEndTs.UTC().Unix()), fmt.Sprintf("%v", someQueryEndTs.UTC().Unix()), false, someQueryEndTs.Add(-1 * minLookback), someQueryEndTs},
 		// Too long, gets adjusted
+		{"1000h", "", "", false, someQueryEndTs.Add(-1 * someMaxLookBack), someQueryEndTs},
 		{"", fmt.Sprintf("%v", someQueryEndTs.Add(-1000*time.Hour).UTC().Unix()), fmt.Sprintf("%v", someQueryEndTs.UTC().Unix()), false, someQueryEndTs.Add(-1 * someMaxLookBack), someQueryEndTs},
 		// Ends in the future
 		{"", fmt.Sprintf("%v", someQueryEndTs.Add(time.Minute*-15).UTC().Unix()), fmt.Sprintf("%v", someQueryEndTs.Add(time.Minute*15).UTC().Unix()), false, someQueryEndTs.Add(time.Minute * -30), someQueryEndTs},


### PR DESCRIPTION
Problem:
Custom Time Search new UI has end time set either as default now or as customer input. 

Solution:
Update computeTimeRangeInternal function to make sure no error return when endTimeVal and lookBackVal are given

Note:
1) keep startTimeVal as a parameter for now even though its not exposed to both current/new UI, will totally remove startTimeVal once we are sure its not used anywhere in new feature.
2) Keep the input validation for now even though the new feature ensures lookBackVal will not be empty.