### PR TITLE
Add custom time window which enables users to select the end time

### DIFF
--- a/pkg/sloop/webserver/webfiles/index.html
+++ b/pkg/sloop/webserver/webfiles/index.html
@@ -112,5 +112,5 @@ For full license text, see LICENSE.txt file in the repo root or https://opensour
         document.getElementById("datafilelink").href = dataQueryUrl;
     </script>
     <script src="webfiles/sloop_ui.js"></script>
-</div>
+    </div>
 </body>

--- a/pkg/sloop/webserver/webfiles/index.html
+++ b/pkg/sloop/webserver/webfiles/index.html
@@ -16,6 +16,9 @@ For full license text, see LICENSE.txt file in the repo root or https://opensour
     <title>Sloop{{if (ne .CurrentContext "")}} - {{.CurrentContext}}{{end}}</title>
     <link rel="stylesheet" type="text/css" href="webfiles/sloop.css">
     <link rel='shortcut icon' type='image/x-icon' href='webfiles/favicon.ico'/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+          integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2"
+          crossorigin="anonymous">
 </head>
 
 <body>
@@ -33,7 +36,12 @@ For full license text, see LICENSE.txt file in the repo root or https://opensour
             <select name="query" id="filterquery" hidden="true"> </select>
             <!-- <br><br> -->
 
-            <label for="filterlookback">Time Range:</label><br/>
+            <label for="selectedEndTime">End time</label><br/>
+            <div>
+                <input type="datetime-local" step="1" id="selectedEndTime" name="selectedEndTime" />
+            </div><br>
+
+            <label for="filterlookback">Look Back Range:</label><br/>
             <select name="lookback" id="filterlookback">
                 <option value="1h">1 Hour</option>
                 <option value="3h">3 Hours</option>
@@ -104,5 +112,5 @@ For full license text, see LICENSE.txt file in the repo root or https://opensour
         document.getElementById("datafilelink").href = dataQueryUrl;
     </script>
     <script src="webfiles/sloop_ui.js"></script>
-    </div>
+</div>
 </body>

--- a/pkg/sloop/webserver/webfiles/sloop.css
+++ b/pkg/sloop/webserver/webfiles/sloop.css
@@ -129,3 +129,8 @@ a[target="_blank"]:after {
 	margin: 0 3px 0 5px;
 }
 
+input[type="datetime-local"] {
+	width: 200px;
+	height: 1.3rem;
+	font-size: 0.85em;
+}

--- a/pkg/sloop/webserver/webfiles/sloop_ui.js
+++ b/pkg/sloop/webserver/webfiles/sloop_ui.js
@@ -515,3 +515,19 @@ function showDetailedTooltip(d, event, parent) {
         });
     }
 }
+
+$(document).ready(function() {
+    //set max allowed selected date to now
+    var iso = new Date().toISOString();
+    var maxDate = iso.substring(0,iso.length-1);
+    elem = document.getElementById("selectedEndTime")
+    elem.value = maxDate
+    elem.max = maxDate
+
+    //set default end time to now
+    const now = new Date();
+    now.setMinutes(now.getMinutes() - now.getTimezoneOffset());
+    now.setMilliseconds(null);
+    document.getElementById('selectedEndTime').value = now.toISOString().slice(0, -1);
+
+});


### PR DESCRIPTION
Problem:
Custom Time Search new UI should have a new window which enables user to select end time

Solution:
Add custom time window for end time. 
The ui will render such behavior:
1) The default of the end time is now, after the page refreshes or a submit is clicked(query is sent to backend), the date on ui will be 'now', which is expected behavior.
2) The max allowed user selected time is set to now to prevent users enter invalid date.

UI screenshot
<img width="1012" alt="Screen Shot 2021-04-01 at 9 14 16 AM" src="https://user-images.githubusercontent.com/78186416/113351693-10682880-92f0-11eb-91fd-f0a2f2d273d0.png">
