### PR TITLE
EndTimeParam in params sync with filter.js

### DIFF
--- a/pkg/sloop/queries/params.go
+++ b/pkg/sloop/queries/params.go
@@ -17,7 +17,7 @@ const (
 	NameMatchParam = "namematch" // substring match on name
 	UuidParam      = "uuid"
 	StartTimeParam = "start_time"
-	EndTimeParam   = "end_time"
+	EndTimeParam   = "endtime"
 	ClickTimeParam = "click_time"
 	QueryParam     = "query"
 	SortParam      = "sort"


### PR DESCRIPTION
Problem: 
Currently in params.go file, params EndTimeParam = "end_time" does not match endtime param in pkg/sloop/webserver/webfiles/filter.js [here](https://github.com/salesforce/sloop/blob/master/pkg/sloop/webserver/webfiles/filter.js#L113), which cause incorrect render results. 

Requirement for sync up [here](https://github.com/salesforce/sloop/blob/master/pkg/sloop/queries/params.go#L11)

Solution: 
Set EndTimeParam = "endtime" in params.go file to sync with filter.js