### PR TITLE
Add helm options for config, pullPolicy and apiGroups

### DIFF
--- a/helm/sloop/templates/clusterrole.yaml
+++ b/helm/sloop/templates/clusterrole.yaml
@@ -8,9 +8,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: {{ .Values.name }}
 rules:
-  - apiGroups: 
+  - apiGroups:
       - ""
-    resources: 
+    resources:
       - configmaps
       - endpoints
       - events
@@ -23,62 +23,62 @@ rules:
       - replicationcontrollers
       - resourcequotas
       - services
-    verbs: 
+    verbs:
       - list
       - watch
-  - apiGroups: 
+  - apiGroups:
       - batch
-    resources: 
+    resources:
       - cronjobs
       - jobs
-    verbs: 
+    verbs:
       - list
       - watch
-  - apiGroups: 
+  - apiGroups:
       - extensions
       - apps
-    resources: 
+    resources:
       - daemonsets
       - deployments
       - replicasets
       - statefulsets
-    verbs: 
+    verbs:
       - list
       - watch
-  - apiGroups: 
+  - apiGroups:
       - autoscaling
-    resources: 
+    resources:
       - horizontalpodautoscalers
-    verbs: 
+    verbs:
       - list
       - watch
-  - apiGroups: 
+  - apiGroups:
       - extensions
       - networking.k8s.io
-    resources: 
+    resources:
       - ingress
-    verbs: 
+    verbs:
       - list
       - watch
-  - apiGroups: 
+  - apiGroups:
       - policy
-    resources: 
+    resources:
       - poddisruptionbudgets
-    verbs: 
+    verbs:
       - list
       - watch
-  - apiGroups: 
+  - apiGroups:
       - storage.k8s.io
-    resources: 
+    resources:
       - storageclasses
-    verbs: 
+    verbs:
       - list
       - watch
-  - apiGroups: 
+  - apiGroups:
       - autoscaling.k8s.io
-    resources: 
+    resources:
       - verticalpodautoscalers
-    verbs: 
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -88,17 +88,14 @@ rules:
     verbs:
       - list
       - watch
-# List CRDs that you want to watch here
-# Istio is just here as an example.  Alternatively if you want to get all CRDs its possible to add '*'
-# to apiGroups, but that would give sloop permissions to read secrets which may not be desirable
+{{- with .Values.clusterRole.apiGroups }}
   - apiGroups:
-      - authentication.istio.io
-      - config.istio.io
-      - networking.istio.io
-      - rbac.istio.io
-      - security.istio.io
+{{- range . }}
+      - {{ . }}
+{{- end }}
     resources:
       - '*'
     verbs:
       - list
       - watch
+{{- end }}

--- a/helm/sloop/templates/configmap.yaml
+++ b/helm/sloop/templates/configmap.yaml
@@ -9,14 +9,4 @@ metadata:
   name: {{ .Values.name }}
 data:
   sloop.json: |-
-    {
-      defaultNamespace: "default",
-      defaultKind: "Pod",
-      defaultLookback: "1h",
-      leftBarLinks: [
-      ],
-      resourceLinks: [
-      ]
-    }
-
-
+{{ .Values.config | indent 4 }}

--- a/helm/sloop/templates/statefulset.yaml
+++ b/helm/sloop/templates/statefulset.yaml
@@ -25,6 +25,7 @@ spec:
         command:
         - /sloop
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: sloop
         ports:
         - containerPort: {{ .Values.service.targetPort }}
@@ -72,9 +73,9 @@ spec:
     spec:
      accessModes:
        - {{ .Values.persistentVolume.dataAccessMode | quote }}
-{{- if .Values.persistentVolume.storageClass }}     
+{{- if .Values.persistentVolume.storageClass }}
      storageClassName: "{{ .Values.persistentVolume.storageClass }}"
-{{- end }}     
+{{- end }}
      resources:
        requests:
          storage: {{ .Values.persistentVolume.size }}

--- a/helm/sloop/values.yaml
+++ b/helm/sloop/values.yaml
@@ -4,7 +4,7 @@ replicas: 1
 image:
   tag: latest
   repository: sloopimage/sloop
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 persistentVolume:
   ## If defined it will specify the storageClass for the statefulSet
   ## If undefined it will use the cluster default (typically gp2 on AWS, standard on GKE)

--- a/helm/sloop/values.yaml
+++ b/helm/sloop/values.yaml
@@ -4,10 +4,11 @@ replicas: 1
 image:
   tag: latest
   repository: sloopimage/sloop
+  pullPolicy: Always
 persistentVolume:
-## If defined it will specify the storageClass for the statefulSet
-## If undefined it will use the cluster default (typically gp2 on AWS, standard on GKE)
-#  storageClass: 
+  ## If defined it will specify the storageClass for the statefulSet
+  ## If undefined it will use the cluster default (typically gp2 on AWS, standard on GKE)
+  #  storageClass:
   size: 10Gi
   dataAccessMode: ReadWriteOnce
   sizeLimit: 12Gi
@@ -32,7 +33,30 @@ readinessProbe:
   failureThreshold: 3
   successThreshold: 1
 ingress:
- enabled: false
- host: sloop.example.com
- annotations: {}
- tls: {}
+  enabled: false
+  host: sloop.example.com
+  annotations: {}
+  tls: {}
+
+config: |-
+  {
+    "displayContext": "cluster",
+    "defaultNamespace": "default",
+    "defaultKind": "Pod",
+    "defaultLookback": "1h",
+    "leftBarLinks": [
+    ],
+    "resourceLinks": [
+    ]
+  }
+
+clusterRole:
+  # List CRD apiGroups that you want to watch here
+  # Istio is just here as an example.  Alternatively if you want to get all CRDs its possible to add '*'
+  # to apiGroups, but that would give sloop permissions to read secrets which may not be desirable
+  apiGroups:
+    - authentication.istio.io
+    - config.istio.io
+    - networking.istio.io
+    - rbac.istio.io
+    - security.istio.io


### PR DESCRIPTION
I had to make some changes to the helm chart to get it usable in our cluster, including control over the bits needed from the external values file.

Note I had to define a non-empty displayContext also, to avoid getting stuck in a redirect loop, not sure if this a bug or not.

Sorry my auto-formatting editor has put in a bunch of whitespace fixups, hope you don't mind them included...