### PR TITLE
Fix Details dialog with no payload entries

### DIFF
--- a/pkg/sloop/queries/eventquery_test.go
+++ b/pkg/sloop/queries/eventquery_test.go
@@ -91,7 +91,7 @@ func Test_GetEventData_True(t *testing.T) {
 	values := helper_get_params()
 	values[KindParam] = []string{"someKinda"}
 	values[NamespaceParam] = []string{"someNamespace"}
-	values[NameParam] = []string{"someName"}
+	values[NameParam] = []string{"someName.xx"}
 	var keys []string
 	keys = append(keys, typed.NewWatchTableKey(partitionId, "Event", "someNamespace", "someName.xx", someTs).String())
 	keys = append(keys, typed.NewWatchTableKey(partitionId, "Event", "someNamespaceb", "someName.xx", someTs).String())

--- a/pkg/sloop/queries/respayloadquery_test.go
+++ b/pkg/sloop/queries/respayloadquery_test.go
@@ -228,7 +228,7 @@ func Test_GetResPayload_NoDataInTimeRangeStillFindsPayload(t *testing.T) {
 	keys = append(keys, typed.NewWatchTableKey(partitionId, expectedKind, expectedNS, expectedName, someTs).String())
 	tables := helper_get_resPayload(keys, t, somePTime)
 
-	queryTs := someTs.Add(5*time.Hour)
+	queryTs := someTs.Add(5 * time.Hour)
 	res, err := GetResPayload(values, tables, queryTs.Add(-15*time.Minute), queryTs.Add(15*time.Minute), someRequestId)
 	assert.Nil(t, err)
 	expectedRes := `[

--- a/pkg/sloop/queries/respayloadquery_test.go
+++ b/pkg/sloop/queries/respayloadquery_test.go
@@ -213,6 +213,34 @@ func Test_GetResPayload_True_HasSamePrefix(t *testing.T) {
 	assertex.JsonEqual(t, expectedRes, string(res))
 }
 
+func Test_GetResPayload_NoDataInTimeRangeStillFindsPayload(t *testing.T) {
+	untyped.TestHookSetPartitionDuration(time.Hour)
+	partitionId := untyped.GetPartitionId(someTs)
+	values := helper_get_params()
+	expectedKind := "someKind"
+	expectedNS := "someNamespace"
+	expectedName := "someName"
+	values[KindParam] = []string{expectedKind}
+	values[NamespaceParam] = []string{expectedNS}
+	values[NameParam] = []string{expectedName}
+
+	var keys []string
+	keys = append(keys, typed.NewWatchTableKey(partitionId, expectedKind, expectedNS, expectedName, someTs).String())
+	tables := helper_get_resPayload(keys, t, somePTime)
+
+	queryTs := someTs.Add(5*time.Hour)
+	res, err := GetResPayload(values, tables, queryTs.Add(-15*time.Minute), queryTs.Add(15*time.Minute), someRequestId)
+	assert.Nil(t, err)
+	expectedRes := `[
+ {
+  "payloadTime": 1546398245000000006,
+  "payload": "{\n  \"metadata\": {\n    \"name\": \"someName\",\n    \"namespace\": \"someNamespace\",\n    \"uid\": \"6c2a9795-a282-11e9-ba2f-14187761de09\",\n    \"creationTimestamp\": \"2019-07-09T19:47:45Z\"\n  }\n}",
+  "payloadKey": "/watch/001546398000/someKind/someNamespace/someName/1546398245000000006"
+ }
+]`
+	assertex.JsonEqual(t, expectedRes, string(res))
+}
+
 func Test_getSeekKey(t *testing.T) {
 	untyped.TestHookSetPartitionDuration(time.Hour)
 


### PR DESCRIPTION
Problem: sometimes clicking on an object's history bar brings up a Detail dialog with an empty set of Payloads instead of at least one

The root of the problem is that the method `getSeekKey()` would return a pointer to the source key instead of a duplicate and would mutate the source key.

In GetResPayload(), after the RangeRead, the implementation goes looking for the closest, older key and adds the corresponding payload to the result - this was to ensure the collection always has at least one entry.

To find the closest, older payload, a seekKey is generated from the keyComparator and both are passed in to GetPreviousKey(). The seekKey is mutated with the partition Id while walking backward in time. Each partition is searched by getLastMatchingKeyInPartition() using the seekKey and comparing the found keys against the keyComparator as a prefix.
The keyComparator is constructed without a timestamp. When converted to a string the timestamp is left off. Using this for a prefix match against the database keys.

When seekKey & keyComparator are referring to the same object, the time stamp in seekKey is also part of keyComparator. Then the string form of keyComparator contains a timestamp and never matches against any key coming out of the database.

I also added some verbose logs to expose what is happening for each call to `GetResPayload`
Further testing has not shown an empty payload list (1 corner case - see below)


corner case - early in the Sloop process life when the history of the data is short, if the UI is showing many hours (I was using 6) an existing object is presented as a bar filling left to right of the entire field. The implies that Sloop has data for the entire presented time range. Clicking on an older timestamp for the object may still see 0 payloads. The GetPreviousKey() logic explained above has no previous partitions to compare against.
