### PR TITLE
Cleaned up logs for Sloop

### DIFF
--- a/pkg/sloop/common/constants.go
+++ b/pkg/sloop/common/constants.go
@@ -1,0 +1,5 @@
+package common
+
+const (
+	GlogVerbose = 10
+)

--- a/pkg/sloop/ingress/kubewatcher.go
+++ b/pkg/sloop/ingress/kubewatcher.go
@@ -10,6 +10,7 @@ package ingress
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/salesforce/sloop/pkg/sloop/common"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -306,7 +307,7 @@ func (i *kubeWatcherImpl) processUpdate(kind string, obj interface{}, watchResul
 	metricIngressKubewatchcount.WithLabelValues(kind, watchResult.WatchType.String(), kubeMetadata.Namespace).Inc()
 	metricIngressKubewatchbytes.WithLabelValues(kind, watchResult.WatchType.String(), kubeMetadata.Namespace).Add(float64(len(resourceJson)))
 
-	glog.V(5).Infof("Informer update (%s) - Name: %s, Namespace: %s, ResourceVersion: %s", watchResult.WatchType, kubeMetadata.Name, kubeMetadata.Namespace, kubeMetadata.ResourceVersion)
+	glog.V(common.GlogVerbose).Infof("Informer update (%s) - Name: %s, Namespace: %s, ResourceVersion: %s", watchResult.WatchType, kubeMetadata.Name, kubeMetadata.Namespace, kubeMetadata.ResourceVersion)
 	watchResult.Payload = resourceJson
 	i.writeToOutChan(watchResult)
 }
@@ -334,7 +335,7 @@ func (i *kubeWatcherImpl) getResourceAsJsonString(kind string, obj interface{}) 
 
 func (i *kubeWatcherImpl) refreshCrdInformers(masterURL string, kubeContext string) {
 	for range i.refreshCrd.C {
-		glog.Infof("Starting to refresh CRD informers")
+		glog.V(common.GlogVerbose).Infof("Starting to refresh CRD informers")
 		err := i.startCustomInformers(masterURL, kubeContext)
 		if err != nil {
 			glog.Errorf("Failed to refresh CRD informers: %v", err)

--- a/pkg/sloop/queries/respayloadquery.go
+++ b/pkg/sloop/queries/respayloadquery.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"github.com/dgraph-io/badger/v2"
 	"github.com/golang/glog"
+	"github.com/salesforce/sloop/pkg/sloop/common"
 	"github.com/salesforce/sloop/pkg/sloop/kubeextractor"
 	"github.com/salesforce/sloop/pkg/sloop/store/typed"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped"
@@ -19,10 +20,6 @@ import (
 	"net/url"
 	"sort"
 	"time"
-)
-
-const (
-	glogVerbose = 10
 )
 
 type ResPayLoadData struct {
@@ -37,7 +34,7 @@ type PayloadOuput struct {
 
 func GetResPayload(params url.Values, t typed.Tables, startTime time.Time, endTime time.Time, requestId string) ([]byte, error) {
 
-	glog.V(glogVerbose).Infof("GetResPayload: startTime: %v, endTime: %v", startTime.Unix(), endTime.Unix())
+	glog.V(common.GlogVerbose).Infof("GetResPayload: startTime: %v, endTime: %v", startTime.Unix(), endTime.Unix())
 	var watchRes map[typed.WatchTableKey]*typed.KubeWatchResult
 	var previousKey *typed.WatchTableKey
 	var previousVal *typed.KubeWatchResult
@@ -46,40 +43,40 @@ func GetResPayload(params url.Values, t typed.Tables, startTime time.Time, endTi
 		var stats typed.RangeReadStats
 
 		keyComparator := getKeyComparator(params)
-		glog.V(glogVerbose).Infof("GetResPayload: keyComparator: %v", keyComparator.String())
+		glog.V(common.GlogVerbose).Infof("GetResPayload: keyComparator: %v", keyComparator.String())
 		valPredFn := typed.KubeWatchResult_ValPredicateFns(isResPayloadInTimeRange(startTime, endTime))
 
 		var rangeReadErr error
 		watchRes, _, rangeReadErr = t.WatchTable().RangeRead(txn, keyComparator, nil, valPredFn, startTime, endTime)
 		if rangeReadErr != nil {
-			glog.V(glogVerbose).Infof("GetResPayload: range read error: %v", rangeReadErr)
+			glog.V(common.GlogVerbose).Infof("GetResPayload: range read error: %v", rangeReadErr)
 			return rangeReadErr
 		}
-		glog.V(glogVerbose).Infof("GetResPayload: range read found: %v payload", len(watchRes))
+		glog.V(common.GlogVerbose).Infof("GetResPayload: range read found: %v payload", len(watchRes))
 
 		// get the previous key for those who has same payload but just before startTime
 		var getPreviousErr error
-		seekKey := getSeekKey(keyComparator, startTime)
-		glog.V(glogVerbose).Infof("GetResPayload: seekKey: %v", seekKey.String())
+		seekKey := GetSeekKey(keyComparator, startTime)
+		glog.V(common.GlogVerbose).Infof("GetResPayload: seekKey: %v", seekKey.String())
 		previousKey, getPreviousErr = t.WatchTable().GetPreviousKey(txn, seekKey, keyComparator)
 
 		// when getPreviousErr is not nil, we will not return err since it is ok we did not find previous key from startTime,
 		// we can continue using the result from rangeRead to proceed the rest payload
 		if getPreviousErr == nil {
-			glog.V(glogVerbose).Infof("GetResPayload: previousKey: %v", previousKey.String())
+			glog.V(common.GlogVerbose).Infof("GetResPayload: previousKey: %v", previousKey.String())
 			var getErr error
 			previousVal, getErr = t.WatchTable().Get(txn, previousKey.String())
 			if getErr == nil {
 				watchRes[*previousKey] = previousVal
 			} else {
-				glog.V(glogVerbose).Infof("GetResPayload: getErr: %v", getErr)
+				glog.V(common.GlogVerbose).Infof("GetResPayload: getErr: %v", getErr)
 				// we need to return error when getErr is not nil and its error is not keyNotFound
 				if getErr != badger.ErrKeyNotFound {
 					return getErr
 				}
 			}
 		} else {
-			glog.V(glogVerbose).Infof("GetResPayload: no previous key found. seekKey: %v, err: %v", seekKey.String(), getPreviousErr)
+			glog.V(common.GlogVerbose).Infof("GetResPayload: no previous key found. seekKey: %v, err: %v", seekKey.String(), getPreviousErr)
 		}
 
 		stats.Log(requestId)
@@ -105,7 +102,7 @@ func GetResPayload(params url.Values, t typed.Tables, startTime time.Time, endTi
 	return bytes, nil
 }
 
-func getSeekKey(keyComparator *typed.WatchTableKey, startTime time.Time) *typed.WatchTableKey {
+func GetSeekKey(keyComparator *typed.WatchTableKey, startTime time.Time) *typed.WatchTableKey {
 	kind := keyComparator.Kind
 	namespace := keyComparator.Namespace
 	name := keyComparator.Name
@@ -150,10 +147,10 @@ func removeDupePayloads(payloads []PayloadOuput) []PayloadOuput {
 	lastPayload := ""
 	for _, val := range payloads {
 		if val.Payload != lastPayload {
-			glog.V(glogVerbose).Infof("removeDupePayloads: found key: %v", len(val.PayloadKey))
+			glog.V(common.GlogVerbose).Infof("removeDupePayloads: found key: %v", len(val.PayloadKey))
 			ret = append(ret, val)
 		} else {
-			glog.V(glogVerbose).Infof("removeDupePayloads: duplicate key: %v", len(val.PayloadKey))
+			glog.V(common.GlogVerbose).Infof("removeDupePayloads: duplicate key: %v", len(val.PayloadKey))
 		}
 		lastPayload = val.Payload
 	}

--- a/pkg/sloop/queries/respayloadquery.go
+++ b/pkg/sloop/queries/respayloadquery.go
@@ -56,7 +56,7 @@ func GetResPayload(params url.Values, t typed.Tables, startTime time.Time, endTi
 
 		// get the previous key for those who has same payload but just before startTime
 		var getPreviousErr error
-		seekKey := GetSeekKey(keyComparator, startTime)
+		seekKey := getSeekKey(keyComparator, startTime)
 		glog.V(common.GlogVerbose).Infof("GetResPayload: seekKey: %v", seekKey.String())
 		previousKey, getPreviousErr = t.WatchTable().GetPreviousKey(txn, seekKey, keyComparator)
 
@@ -102,7 +102,7 @@ func GetResPayload(params url.Values, t typed.Tables, startTime time.Time, endTi
 	return bytes, nil
 }
 
-func GetSeekKey(keyComparator *typed.WatchTableKey, startTime time.Time) *typed.WatchTableKey {
+func getSeekKey(keyComparator *typed.WatchTableKey, startTime time.Time) *typed.WatchTableKey {
 	kind := keyComparator.Kind
 	namespace := keyComparator.Namespace
 	name := keyComparator.Name

--- a/pkg/sloop/queries/respayloadquery_test.go
+++ b/pkg/sloop/queries/respayloadquery_test.go
@@ -250,7 +250,7 @@ func Test_getSeekKey(t *testing.T) {
 
 	// returns COPY populated with contents from source & adjusts for new time
 	keyComparator := typed.NewWatchTableKey(untyped.GetPartitionId(keyTime), "k", "ns", "n", keyTime)
-	seekKey := GetSeekKey(keyComparator, seekTime)
+	seekKey := getSeekKey(keyComparator, seekTime)
 	assert.Equal(t, untyped.GetPartitionId(seekTime), seekKey.PartitionId)
 	assert.Equal(t, keyComparator.Kind, seekKey.Kind)
 	assert.Equal(t, keyComparator.Namespace, seekKey.Namespace)

--- a/pkg/sloop/queries/respayloadquery_test.go
+++ b/pkg/sloop/queries/respayloadquery_test.go
@@ -250,7 +250,7 @@ func Test_getSeekKey(t *testing.T) {
 
 	// returns COPY populated with contents from source & adjusts for new time
 	keyComparator := typed.NewWatchTableKey(untyped.GetPartitionId(keyTime), "k", "ns", "n", keyTime)
-	seekKey := getSeekKey(keyComparator, seekTime)
+	seekKey := GetSeekKey(keyComparator, seekTime)
 	assert.Equal(t, untyped.GetPartitionId(seekTime), seekKey.PartitionId)
 	assert.Equal(t, keyComparator.Kind, seekKey.Kind)
 	assert.Equal(t, keyComparator.Namespace, seekKey.Namespace)

--- a/pkg/sloop/server/internal/config/config.go
+++ b/pkg/sloop/server/internal/config/config.go
@@ -73,6 +73,7 @@ type SloopConfig struct {
 	BadgerVLogFileIOMapping  bool          `json:"badgerVLogFileIOMapping"`
 	BadgerVLogTruncate       bool          `json:"badgerVLogTruncate"`
 	EnableDeleteKeys         bool          `json:"enableDeleteKeys"`
+	BadgerDetailLogEnabled   bool          `json:"badgerDetailLogEnabled"`
 }
 
 func registerFlags(fs *flag.FlagSet, config *SloopConfig) {
@@ -120,6 +121,7 @@ func registerFlags(fs *flag.FlagSet, config *SloopConfig) {
 	fs.BoolVar(&config.EnableDeleteKeys, "enable-delete-keys", config.EnableDeleteKeys, "Use delete prefixes instead of dropPrefix for GC")
 	fs.BoolVar(&config.BadgerVLogFileIOMapping, "badger-vlog-fileIO-mapping", config.BadgerVLogFileIOMapping, "Indicates which file loading mode should be used for the value log data, in memory constrained environments the value is recommended to be true")
 	fs.BoolVar(&config.BadgerVLogTruncate, "badger-vlog-truncate", config.BadgerVLogTruncate, "Truncate value log if badger db offset is different from badger db size")
+	fs.BoolVar(&config.BadgerDetailLogEnabled, "badger-detail-log-enabled", config.BadgerDetailLogEnabled, "Turns on detailed logging of BadgerDB")
 }
 
 func getDefaultConfig() *SloopConfig {
@@ -167,6 +169,7 @@ func getDefaultConfig() *SloopConfig {
 		BadgerVLogFileIOMapping:  false,
 		BadgerVLogTruncate:       true,
 		EnableDeleteKeys:         false,
+		BadgerDetailLogEnabled:   false,
 	}
 	return &defaultConfig
 }

--- a/pkg/sloop/server/server.go
+++ b/pkg/sloop/server/server.go
@@ -74,6 +74,7 @@ func RealMain() error {
 		BadgerLevSizeMultiplier:  conf.BadgerLevSizeMultiplier,
 		BadgerVLogFileIOMapping:  conf.BadgerVLogFileIOMapping,
 		BadgerVLogTruncate:       conf.BadgerVLogTruncate,
+		BadgerDetailLogEnabled:   conf.BadgerDetailLogEnabled,
 	}
 	db, err := untyped.OpenStore(factory, storeConfig)
 	if err != nil {

--- a/pkg/sloop/store/typed/tabletemplatehelper.go
+++ b/pkg/sloop/store/typed/tabletemplatehelper.go
@@ -9,6 +9,7 @@ package typed
 
 import (
 	"github.com/golang/glog"
+	"github.com/salesforce/sloop/pkg/sloop/common"
 	"time"
 )
 
@@ -78,6 +79,6 @@ type RangeReadStats struct {
 }
 
 func (stats RangeReadStats) Log(requestId string) {
-	glog.Infof("reqId: %v range read on table %v took %v.  Partitions scanned %v.  Rows scanned %v, past key predicate %v, past value predicate %v",
+	glog.V(common.GlogVerbose).Infof("reqId: %v range read on table %v took %v.  Partitions scanned %v.  Rows scanned %v, past key predicate %v, past value predicate %v",
 		requestId, stats.TableName, stats.Elapsed, stats.PartitionCount, stats.RowsVisitedCount, stats.RowsPassedKeyPredicateCount, stats.RowsPassedValuePredicateCount)
 }

--- a/pkg/sloop/store/untyped/store.go
+++ b/pkg/sloop/store/untyped/store.go
@@ -33,6 +33,7 @@ type Config struct {
 	BadgerLevelOneSize       int64
 	BadgerLevSizeMultiplier  int
 	BadgerVLogFileIOMapping  bool
+	BadgerDetailLogEnabled   bool
 	BadgerVLogTruncate       bool
 }
 
@@ -93,6 +94,10 @@ func OpenStore(factory badgerwrap.Factory, config *Config) (badgerwrap.DB, error
 
 	if config.BadgerVLogFileIOMapping {
 		opts = opts.WithValueLogLoadingMode(options.FileIO)
+	}
+
+	if !config.BadgerDetailLogEnabled {
+		opts = opts.WithLogger(nil)
 	}
 
 	opts = opts.WithTruncate(config.BadgerVLogTruncate)

--- a/pkg/sloop/storemanager/stats.go
+++ b/pkg/sloop/storemanager/stats.go
@@ -64,12 +64,12 @@ func generateStats(storeRoot string, db badgerwrap.DB, fs *afero.Afero) *storeSt
 	ret.TotalKeyCount = common.GetTotalKeyCount(db, "")
 	tables := db.Tables(true)
 	for _, table := range tables {
-		glog.V(2).Infof("BadgerDB TABLE id=%v keycount=%v level=%v left=%q right=%q", table.ID, table.KeyCount, table.Level, string(table.Left), string(table.Right))
+		glog.V(common.GlogVerbose).Infof("BadgerDB TABLE id=%v keycount=%v level=%v left=%q right=%q", table.ID, table.KeyCount, table.Level, string(table.Left), string(table.Right))
 		ret.LevelToTableCount[table.Level] += 1
 		ret.LevelToKeyCount[table.Level] += table.KeyCount
 	}
 
-	glog.Infof("Finished updating store stats: %+v", ret)
+	glog.V(common.GlogVerbose).Infof("Finished updating store stats: %+v", ret)
 	return ret
 }
 

--- a/pkg/sloop/storemanager/storemanager.go
+++ b/pkg/sloop/storemanager/storemanager.go
@@ -113,7 +113,7 @@ func (sm *StoreManager) gcLoop() {
 			metricGcFailedCount.Inc()
 		}
 		metricGcLatency.Set(time.Since(before).Seconds())
-		glog.Infof("GC finished in %v with error '%v'.  Next run in %v", time.Since(before), err, sm.config.Freq)
+		glog.V(common.GlogVerbose).Infof("GC finished in %v with error '%v'.  Next run in %v", time.Since(before), err, sm.config.Freq)
 
 		var afterGCEnds = sm.refreshStats()
 		var deltaStats = getDeltaStats(beforeGCStats, afterGCEnds)
@@ -142,7 +142,7 @@ func (sm *StoreManager) vlogGcLoop() {
 			metricValueLogGcRunning.Set(0)
 			metricValueLogGcRunCount.Add(1)
 			metricValueLogGcLatency.Set(time.Since(before).Seconds())
-			glog.Infof("RunValueLogGC(%v) run took %v and returned '%v'", sm.config.BadgerDiscardRatio, time.Since(before), err)
+			glog.V(common.GlogVerbose).Infof("RunValueLogGC(%v) run took %v and returned '%v'", sm.config.BadgerDiscardRatio, time.Since(before), err)
 			if err != nil {
 				break
 			}
@@ -193,14 +193,14 @@ func doCleanup(tables typed.Tables, timeLimit time.Duration, sizeLimitBytes int,
 			return false, totalNumOfDeletedKeys, totalNumOfKeysToDelete, fmt.Errorf(errMsg)
 		}
 
-		glog.Infof("Removed number of keys so far: %v ", totalNumOfDeletedKeys)
+		glog.V(common.GlogVerbose).Infof("Removed number of keys so far: %v ", totalNumOfDeletedKeys)
 		totalNumOfDeletedKeys += int64(numOfDeletedKeysForPrefix)
 		totalNumOfKeysToDelete += int64(numOfKeysToDeleteForPrefix)
 
 	}
 
 	elapsed := time.Since(beforeGCTime)
-	glog.Infof("Deletion/dropPrefix of prefixes took %v:", elapsed)
+	glog.V(common.GlogVerbose).Infof("Deletion/dropPrefix of prefixes took %v:", elapsed)
 
 	if enableDeletePrefix {
 		beforeDropPrefix := time.Now()
@@ -325,7 +325,7 @@ func deletePartition(minPartition string, tables typed.Tables, deletionBatchSize
 		}
 
 		elapsed := time.Since(start)
-		glog.Infof("Call to DropPrefix(%v) took %v and removed %d keys with error: %v", prefix, elapsed, numOfDeletedKeysForPrefix, err)
+		glog.V(common.GlogVerbose).Infof("Call to DropPrefix(%v) took %v and removed %d keys with error: %v", prefix, elapsed, numOfDeletedKeysForPrefix, err)
 		if err != nil {
 			errMessages = append(errMessages, fmt.Sprintf("failed to cleanup with min key: %s, elapsed: %v,err: %v,", prefix, elapsed, err))
 		}


### PR DESCRIPTION
There were a lot of log lines in Sloop which were causing clogging of logs. Updated them to use verbosity and display when needed. There were also a lot of log lines published because of badger. Added a configuration to turn them on/off based on need. By default they are turned off.