### PR TITLE
Fixed missing UID bug

### DIFF
--- a/pkg/sloop/processing/eventcount.go
+++ b/pkg/sloop/processing/eventcount.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/pkg/errors"
+	"github.com/salesforce/sloop/pkg/sloop/common"
 	"github.com/salesforce/sloop/pkg/sloop/kubeextractor"
 	"github.com/salesforce/sloop/pkg/sloop/store/typed"
 	"github.com/salesforce/sloop/pkg/sloop/store/untyped"
@@ -69,6 +70,15 @@ func updateEventCountTable(
 
 	eventCountByMinute := spreadOutEvents(computedFirstTs, computedLastTs, computedCount)
 
+	if involvedObject.Uid == "" {
+		glog.V(common.GlogVerbose).Infof("Got empty Uid for name: %v, namespace: %v, kind: %v for event: %v ", involvedObject.Name, involvedObject.Namespace, involvedObject.Kind, newEventInfo.Reason)
+		returnedUid, err := GetUidForWatchEntry(tables, txn, involvedObject.Kind, involvedObject.Namespace, involvedObject.Name, time.Time{})
+		if err != nil {
+			return errors.Wrap(err, "Error retrieving Uid for the involved object")
+		}
+
+		involvedObject.Uid = returnedUid
+	}
 	err = storeMinutes(tables, txn, eventCountByMinute, involvedObject.Kind, involvedObject.Namespace, involvedObject.Name, involvedObject.Uid, newEventInfo.Reason, newEventInfo.Type)
 	if err != nil {
 		return err

--- a/pkg/sloop/queries/respayloadquery.go
+++ b/pkg/sloop/queries/respayloadquery.go
@@ -56,7 +56,7 @@ func GetResPayload(params url.Values, t typed.Tables, startTime time.Time, endTi
 
 		// get the previous key for those who has same payload but just before startTime
 		var getPreviousErr error
-		seekKey := getSeekKey(keyComparator, startTime)
+		seekKey := GetSeekKey(keyComparator, startTime)
 		glog.V(common.GlogVerbose).Infof("GetResPayload: seekKey: %v", seekKey.String())
 		previousKey, getPreviousErr = t.WatchTable().GetPreviousKey(txn, seekKey, keyComparator)
 
@@ -102,7 +102,7 @@ func GetResPayload(params url.Values, t typed.Tables, startTime time.Time, endTi
 	return bytes, nil
 }
 
-func getSeekKey(keyComparator *typed.WatchTableKey, startTime time.Time) *typed.WatchTableKey {
+func GetSeekKey(keyComparator *typed.WatchTableKey, startTime time.Time) *typed.WatchTableKey {
 	kind := keyComparator.Kind
 	namespace := keyComparator.Namespace
 	name := keyComparator.Name

--- a/pkg/sloop/queries/respayloadquery_test.go
+++ b/pkg/sloop/queries/respayloadquery_test.go
@@ -250,7 +250,7 @@ func Test_getSeekKey(t *testing.T) {
 
 	// returns COPY populated with contents from source & adjusts for new time
 	keyComparator := typed.NewWatchTableKey(untyped.GetPartitionId(keyTime), "k", "ns", "n", keyTime)
-	seekKey := getSeekKey(keyComparator, seekTime)
+	seekKey := GetSeekKey(keyComparator, seekTime)
 	assert.Equal(t, untyped.GetPartitionId(seekTime), seekKey.PartitionId)
 	assert.Equal(t, keyComparator.Kind, seekKey.Kind)
 	assert.Equal(t, keyComparator.Namespace, seekKey.Namespace)


### PR DESCRIPTION
There was an error observed at times while ingesting event count:

`Processing for updateEventCountTable failed with error Could not get event record: invalid key for table eventcount: /eventcount/001630076400/Pod/namespace/podname: key should have 6 parts:`

Fix:
For a certain type of events from Tain Manager the involved object in Event body didn't have UID.
Previously we used to drop all these events and they didn't show up in Sloop UI.
Now, we find the record in Watch table and retrieve the UID if dont get it in Event payload. Hence these payloads are ingested now. 
Also added unit test cases for testing of this scenario.