### PR TITLE
No events bug fix

### DIFF
--- a/pkg/sloop/processing/eventcount_test.go
+++ b/pkg/sloop/processing/eventcount_test.go
@@ -30,7 +30,7 @@ var (
 	lastTimeStamp          = "2019-08-29T21:27:55Z"
 	someEventPayload       = `{
   "metadata": {
-    "name": "someEventName",
+    "name": "somePodName.xx",
     "namespace": "someNamespace",
     "uid": "someEventUid"
   },

--- a/pkg/sloop/queries/eventquery.go
+++ b/pkg/sloop/queries/eventquery.go
@@ -41,6 +41,10 @@ func GetEventData(params url.Values, t typed.Tables, startTime time.Time, endTim
 		selectedName := params.Get(NameParam)
 		selectedKind := params.Get(KindParam)
 
+		// Events are stored with metadata name which are like InvolvedObjectName.XXXX
+		// To ensure we only get events for this resource. Add a '.' delimiter in the end.
+		selectedName = selectedName + "."
+
 		if kubeextractor.IsClustersScopedResource(selectedKind) {
 			selectedNamespace = DefaultNamespace
 		}

--- a/pkg/sloop/queries/eventquery_test.go
+++ b/pkg/sloop/queries/eventquery_test.go
@@ -20,15 +20,15 @@ import (
 
 const someRequestId = "someReqId"
 
-func helper_get_k8Watchtable(keys []string, t *testing.T, somePyaload string) typed.Tables {
-	if len(somePyaload) == 0 {
-		somePyaload = `{
+func helper_get_k8Watchtable(keys []string, t *testing.T, somePayload string) typed.Tables {
+	if len(somePayload) == 0 {
+		somePayload = `{
   "reason":"failed",
   "firstTimestamp": "2019-08-29T21:24:55Z",
   "lastTimestamp": "2019-08-29T21:27:55Z",
   "count": 10}`
 	}
-	val := &typed.KubeWatchResult{Kind: "someKind", Payload: somePyaload}
+	val := &typed.KubeWatchResult{Kind: "Event", Payload: somePayload}
 	db, err := (&badgerwrap.MockFactory{}).Open(badger.DefaultOptions(""))
 	assert.Nil(t, err)
 	wt := typed.OpenKubeWatchResultTable()
@@ -89,17 +89,17 @@ func Test_GetEventData_True(t *testing.T) {
 	untyped.TestHookSetPartitionDuration(time.Hour)
 	partitionId := untyped.GetPartitionId(someTs)
 	values := helper_get_params()
-	values[KindParam] = []string{"someKinda"}
+	values[KindParam] = []string{"someKind"}
 	values[NamespaceParam] = []string{"someNamespace"}
-	values[NameParam] = []string{"someName.xx"}
+	values[NameParam] = []string{"someName"}
 	var keys []string
 	keys = append(keys, typed.NewWatchTableKey(partitionId, "Event", "someNamespace", "someName.xx", someTs).String())
 	keys = append(keys, typed.NewWatchTableKey(partitionId, "Event", "someNamespaceb", "someName.xx", someTs).String())
 	someEventPayload := `{
   "involvedObject": {
-    "kind": "someKinda",
-    "namespace": "user-dmanoharan",
-    "name": "someNamespace",
+    "kind": "someKind",
+    "namespace": "someNamespace",
+    "name": "someName",
     "uid": "someuuid",
     "apiVersion": "v1",
     "resourceVersion": "2716553ddd",
@@ -121,7 +121,7 @@ func Test_GetEventData_True(t *testing.T) {
   "name": "someName.xx",
   "watchTimestamp": "2019-01-02T03:04:05.000000006Z",
   "kind": "Event",
-  "payload": "{\n  \"involvedObject\": {\n    \"kind\": \"someKinda\",\n    \"namespace\": \"user-dmanoharan\",\n    \"name\": \"someNamespace\",\n    \"uid\": \"someuuid\",\n    \"apiVersion\": \"v1\",\n    \"resourceVersion\": \"2716553ddd\",\n    \"fieldPath\": \"spec.containers{xxx}\"\n  },\n        \"reason\":\"someReason\",\n        \"firstTimestamp\": \"2019-01-01T21:24:55Z\",\n        \"lastTimestamp\": \"2019-01-02T21:27:55Z\",\n        \"count\": 10\n    }",
+  "payload": "{\n  \"involvedObject\": {\n    \"kind\": \"someKind\",\n    \"namespace\": \"someNamespace\",\n    \"name\": \"someName\",\n    \"uid\": \"someuuid\",\n    \"apiVersion\": \"v1\",\n    \"resourceVersion\": \"2716553ddd\",\n    \"fieldPath\": \"spec.containers{xxx}\"\n  },\n        \"reason\":\"someReason\",\n        \"firstTimestamp\": \"2019-01-01T21:24:55Z\",\n        \"lastTimestamp\": \"2019-01-02T21:27:55Z\",\n        \"count\": 10\n    }",
   "eventKey": "/watch/001546398000/Event/someNamespace/someName.xx/1546398245000000006"
  }
 ]`

--- a/pkg/sloop/store/typed/watchtable.go
+++ b/pkg/sloop/store/typed/watchtable.go
@@ -68,12 +68,26 @@ func (k *WatchTableKey) SetPartitionId(newPartitionId string) {
 	k.PartitionId = newPartitionId
 }
 
+func (k *WatchTableKey) IsNameAlreadyDelimited() bool {
+	// Currently only '.' or '/' are supported as delimiters
+	nameLength := len(k.Name)
+	if nameLength > 0 && (k.Name[nameLength-1:] == "." || k.Name[nameLength-1:] == "/") {
+		return true
+	}
+
+	return false
+}
+
 //todo: need to make sure it can work as keyPrefix when some fields are empty
 func (k *WatchTableKey) String() string {
 	if k.Name == "" && k.Timestamp.IsZero() {
 		return fmt.Sprintf("/%v/%v/%v/%v/", k.TableName(), k.PartitionId, k.Kind, k.Namespace)
 	} else if k.Timestamp.IsZero() {
-		return fmt.Sprintf("/%v/%v/%v/%v/%v/", k.TableName(), k.PartitionId, k.Kind, k.Namespace, k.Name)
+		if k.IsNameAlreadyDelimited() {
+			return fmt.Sprintf("/%v/%v/%v/%v/%v", k.TableName(), k.PartitionId, k.Kind, k.Namespace, k.Name)
+		} else {
+			return fmt.Sprintf("/%v/%v/%v/%v/%v/", k.TableName(), k.PartitionId, k.Kind, k.Namespace, k.Name)
+		}
 	} else {
 		return fmt.Sprintf("/%v/%v/%v/%v/%v/%v", k.TableName(), k.PartitionId, k.Kind, k.Namespace, k.Name, k.Timestamp.UnixNano())
 	}

--- a/pkg/sloop/store/typed/watchtable_test.go
+++ b/pkg/sloop/store/typed/watchtable_test.go
@@ -195,6 +195,28 @@ func Test_GetPreviousKey_Fail(t *testing.T) {
 	assert.Equal(t, &WatchTableKey{}, partRes)
 }
 
+func Test_String(t *testing.T) {
+	someKindWatchKey := NewWatchTableKey(someMaxPartition, someKind, someNamespace, someName, someTs)
+	someKindWatchKeyStr := someKindWatchKey.String()
+	assert.Equal(t, someKindWatchKeyStr, "/watch/001546405200/somekind/somenamespace/somename/1546398245000000006")
+
+	someKindWatchKey = NewWatchTableKey(someMaxPartition, someKind, someNamespace, someName + ".xx", someTs)
+	someKindWatchKeyStr = someKindWatchKey.String()
+	assert.Equal(t, someKindWatchKeyStr, "/watch/001546405200/somekind/somenamespace/somename.xx/1546398245000000006")
+
+	someKindWatchKey = NewWatchTableKey(someMaxPartition, someKind, someNamespace, someName + ".", time.Time{})
+	someKindWatchKeyStr = someKindWatchKey.String()
+	assert.Equal(t, someKindWatchKeyStr, "/watch/001546405200/somekind/somenamespace/somename.")
+
+	someKindWatchKey = NewWatchTableKey(someMaxPartition, someKind, someNamespace, someName + "/", time.Time{})
+	someKindWatchKeyStr = someKindWatchKey.String()
+	assert.Equal(t, someKindWatchKeyStr, "/watch/001546405200/somekind/somenamespace/somename/")
+
+	someKindWatchKey = NewWatchTableKey(someMaxPartition, someKind, someNamespace, someName +".xx", time.Time{})
+	someKindWatchKeyStr = someKindWatchKey.String()
+	assert.Equal(t, someKindWatchKeyStr, "/watch/001546405200/somekind/somenamespace/somename.xx/")
+}
+
 func (*WatchTableKey) GetTestKey() string {
 	k := NewWatchTableKey(someMinPartition, someKind, someNamespace, someName, someTs)
 	return k.String()

--- a/pkg/sloop/store/typed/watchtable_test.go
+++ b/pkg/sloop/store/typed/watchtable_test.go
@@ -200,19 +200,19 @@ func Test_String(t *testing.T) {
 	someKindWatchKeyStr := someKindWatchKey.String()
 	assert.Equal(t, someKindWatchKeyStr, "/watch/001546405200/somekind/somenamespace/somename/1546398245000000006")
 
-	someKindWatchKey = NewWatchTableKey(someMaxPartition, someKind, someNamespace, someName + ".xx", someTs)
+	someKindWatchKey = NewWatchTableKey(someMaxPartition, someKind, someNamespace, someName+".xx", someTs)
 	someKindWatchKeyStr = someKindWatchKey.String()
 	assert.Equal(t, someKindWatchKeyStr, "/watch/001546405200/somekind/somenamespace/somename.xx/1546398245000000006")
 
-	someKindWatchKey = NewWatchTableKey(someMaxPartition, someKind, someNamespace, someName + ".", time.Time{})
+	someKindWatchKey = NewWatchTableKey(someMaxPartition, someKind, someNamespace, someName+".", time.Time{})
 	someKindWatchKeyStr = someKindWatchKey.String()
 	assert.Equal(t, someKindWatchKeyStr, "/watch/001546405200/somekind/somenamespace/somename.")
 
-	someKindWatchKey = NewWatchTableKey(someMaxPartition, someKind, someNamespace, someName + "/", time.Time{})
+	someKindWatchKey = NewWatchTableKey(someMaxPartition, someKind, someNamespace, someName+"/", time.Time{})
 	someKindWatchKeyStr = someKindWatchKey.String()
 	assert.Equal(t, someKindWatchKeyStr, "/watch/001546405200/somekind/somenamespace/somename/")
 
-	someKindWatchKey = NewWatchTableKey(someMaxPartition, someKind, someNamespace, someName +".xx", time.Time{})
+	someKindWatchKey = NewWatchTableKey(someMaxPartition, someKind, someNamespace, someName+".xx", time.Time{})
 	someKindWatchKeyStr = someKindWatchKey.String()
 	assert.Equal(t, someKindWatchKeyStr, "/watch/001546405200/somekind/somenamespace/somename.xx/")
 }


### PR DESCRIPTION
After a recent change the events stopped showing up in Sloop UI when there was an event indicated by yellow/green capsules.

    Fix:

    In event type we have names in watch key as /watch/partitionID/Event/Namespace/Name.xx

    With the recent change it resulted in watch key to be /watch/partitionID/Event/Namespace/Name/ and thus no events matched this prefix. This a fix to deal with Events type and make it work for all K8s kinds.

    Also added unit test cases and fixed the integration unit test case which should have caught the issue in the previous check in.