### PR TITLE
Fix for #157: Load Azure auth plugin for K8s client

### DIFF
--- a/pkg/sloop/ingress/kubeclient.go
+++ b/pkg/sloop/ingress/kubeclient.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/azure"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 )


### PR DESCRIPTION
Fixes the issue https://github.com/salesforce/sloop/issues/157

Load the azure auth plugin to prevent initialization failure in case k8s clusters use azure authentication.

Reproduced and fix validated on local. 

@sana-jawad Please review