### PR TITLE
add handling for special delete object

### DIFF
--- a/pkg/sloop/ingress/kubewatcher.go
+++ b/pkg/sloop/ingress/kubewatcher.go
@@ -270,6 +270,11 @@ func (i *kubeWatcherImpl) reportAdd(kind string) func(interface{}) {
 
 func (i *kubeWatcherImpl) reportDelete(kind string) func(interface{}) {
 	return func(obj interface{}) {
+		delObj, ok := obj.(cache.DeletedFinalStateUnknown)
+		if ok {
+			obj = delObj.Obj
+		}
+
 		watchResultShell := &typed.KubeWatchResult{
 			Timestamp: ptypes.TimestampNow(),
 			Kind:      kind,
@@ -298,6 +303,7 @@ func (i *kubeWatcherImpl) processUpdate(kind string, obj interface{}, watchResul
 		glog.Error(err)
 		return
 	}
+	glog.V(99).Infof("processUpdate: obj json: %v", resourceJson)
 
 	kubeMetadata, err := kubeextractor.ExtractMetadata(resourceJson)
 	if err != nil || kubeMetadata.Namespace == "" {

--- a/pkg/sloop/ingress/kubewatcher_test.go
+++ b/pkg/sloop/ingress/kubewatcher_test.go
@@ -157,6 +157,14 @@ func Test_reportDelete(t *testing.T) {
 	assert.Equal(t, typed.KubeWatchResult_DELETE, result.WatchType)
 	assert.Equal(t, string(bytes), result.Payload)
 
+	deleteObj := cache.DeletedFinalStateUnknown{
+		Key: "object-key",
+		Obj: obj,
+	}
+	report(deleteObj)
+	result = <-outChan
+	assert.Equal(t, string(bytes), result.Payload)
+
 	verifyChannelEmpty(t, outChan)
 }
 

--- a/pkg/sloop/processing/processing.go
+++ b/pkg/sloop/processing/processing.go
@@ -55,6 +55,7 @@ func (r *Runner) Start() {
 			if err != nil {
 				r.processingFailed("cannot extract resource metadata", err)
 			}
+			glog.V(99).Infof("watchRec metadata: %v", resourceMetadata)
 			involvedObject, err := kubeextractor.ExtractInvolvedObject(watchRec.Payload)
 			if err != nil {
 				r.processingFailed("cannot extract involved object", err)

--- a/pkg/sloop/webserver/bindata.go
+++ b/pkg/sloop/webserver/bindata.go
@@ -413,20 +413,20 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"webfiles/debug.html": webfilesDebugHtml,
-	"webfiles/debug.js": webfilesDebugJs,
-	"webfiles/debugconfig.html": webfilesDebugconfigHtml,
+	"webfiles/debug.html":          webfilesDebugHtml,
+	"webfiles/debug.js":            webfilesDebugJs,
+	"webfiles/debugconfig.html":    webfilesDebugconfigHtml,
 	"webfiles/debughistogram.html": webfilesDebughistogramHtml,
-	"webfiles/debuglistkeys.html": webfilesDebuglistkeysHtml,
-	"webfiles/debugtables.html": webfilesDebugtablesHtml,
-	"webfiles/debugviewkey.html": webfilesDebugviewkeyHtml,
-	"webfiles/favicon.ico": webfilesFaviconIco,
-	"webfiles/filter.js": webfilesFilterJs,
-	"webfiles/index.html": webfilesIndexHtml,
-	"webfiles/resource.css": webfilesResourceCss,
-	"webfiles/resource.html": webfilesResourceHtml,
-	"webfiles/sloop.css": webfilesSloopCss,
-	"webfiles/sloop_ui.js": webfilesSloop_uiJs,
+	"webfiles/debuglistkeys.html":  webfilesDebuglistkeysHtml,
+	"webfiles/debugtables.html":    webfilesDebugtablesHtml,
+	"webfiles/debugviewkey.html":   webfilesDebugviewkeyHtml,
+	"webfiles/favicon.ico":         webfilesFaviconIco,
+	"webfiles/filter.js":           webfilesFilterJs,
+	"webfiles/index.html":          webfilesIndexHtml,
+	"webfiles/resource.css":        webfilesResourceCss,
+	"webfiles/resource.html":       webfilesResourceHtml,
+	"webfiles/sloop.css":           webfilesSloopCss,
+	"webfiles/sloop_ui.js":         webfilesSloop_uiJs,
 }
 
 // AssetDir returns the file names below a certain
@@ -468,22 +468,23 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
 	"webfiles": &bintree{nil, map[string]*bintree{
-		"debug.html": &bintree{webfilesDebugHtml, map[string]*bintree{}},
-		"debug.js": &bintree{webfilesDebugJs, map[string]*bintree{}},
-		"debugconfig.html": &bintree{webfilesDebugconfigHtml, map[string]*bintree{}},
+		"debug.html":          &bintree{webfilesDebugHtml, map[string]*bintree{}},
+		"debug.js":            &bintree{webfilesDebugJs, map[string]*bintree{}},
+		"debugconfig.html":    &bintree{webfilesDebugconfigHtml, map[string]*bintree{}},
 		"debughistogram.html": &bintree{webfilesDebughistogramHtml, map[string]*bintree{}},
-		"debuglistkeys.html": &bintree{webfilesDebuglistkeysHtml, map[string]*bintree{}},
-		"debugtables.html": &bintree{webfilesDebugtablesHtml, map[string]*bintree{}},
-		"debugviewkey.html": &bintree{webfilesDebugviewkeyHtml, map[string]*bintree{}},
-		"favicon.ico": &bintree{webfilesFaviconIco, map[string]*bintree{}},
-		"filter.js": &bintree{webfilesFilterJs, map[string]*bintree{}},
-		"index.html": &bintree{webfilesIndexHtml, map[string]*bintree{}},
-		"resource.css": &bintree{webfilesResourceCss, map[string]*bintree{}},
-		"resource.html": &bintree{webfilesResourceHtml, map[string]*bintree{}},
-		"sloop.css": &bintree{webfilesSloopCss, map[string]*bintree{}},
-		"sloop_ui.js": &bintree{webfilesSloop_uiJs, map[string]*bintree{}},
+		"debuglistkeys.html":  &bintree{webfilesDebuglistkeysHtml, map[string]*bintree{}},
+		"debugtables.html":    &bintree{webfilesDebugtablesHtml, map[string]*bintree{}},
+		"debugviewkey.html":   &bintree{webfilesDebugviewkeyHtml, map[string]*bintree{}},
+		"favicon.ico":         &bintree{webfilesFaviconIco, map[string]*bintree{}},
+		"filter.js":           &bintree{webfilesFilterJs, map[string]*bintree{}},
+		"index.html":          &bintree{webfilesIndexHtml, map[string]*bintree{}},
+		"resource.css":        &bintree{webfilesResourceCss, map[string]*bintree{}},
+		"resource.html":       &bintree{webfilesResourceHtml, map[string]*bintree{}},
+		"sloop.css":           &bintree{webfilesSloopCss, map[string]*bintree{}},
+		"sloop_ui.js":         &bintree{webfilesSloop_uiJs, map[string]*bintree{}},
 	}},
 }}
 
@@ -533,4 +534,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-


### PR DESCRIPTION
P: When receiving cache.DeletedFinalStateUnknown in reportDelete(), the object is contained inside. Downstream processing wasn't recognizing it as a k8s object.
S: Process the contained object as the delete instead of the cache.DeletedFinalStateUnknown object

I believe all the changes to bindata.go are formatting changes.