### PR TITLE
Make the Helm chart compatible with new Kubernetes API

### DIFF
--- a/helm/sloop/templates/clusterrole.yaml
+++ b/helm/sloop/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:

--- a/helm/sloop/templates/clusterrolebinding.yaml
+++ b/helm/sloop/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/helm/sloop/templates/ingress.yaml
+++ b/helm/sloop/templates/ingress.yaml
@@ -13,6 +13,9 @@ metadata:
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
   name: {{ .Values.name }}
 spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   rules:
   - host: {{ .Values.ingress.host }}
     http:

--- a/helm/sloop/templates/ingress.yaml
+++ b/helm/sloop/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -18,9 +18,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: {{ .Values.name }}
-          servicePort: {{ .Values.service.port }}
+          service:
+            name: {{ .Values.name }}
+            port:
+              number: {{ .Values.service.port }}
         path: /
+        pathType: Prefix
 {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:

--- a/helm/sloop/values.yaml
+++ b/helm/sloop/values.yaml
@@ -37,7 +37,7 @@ ingress:
   host: sloop.example.com
   annotations: {}
   tls: {}
-
+  # className: nginx
 config: |-
   {
     "displayContext": "cluster",


### PR DESCRIPTION
In the issue #195 I mentioned that the Ingress manifest within the Helm chart has to be updated to be compatible with a modern Kubernetes API.

This PR does that :-)