### PR TITLE
.goreleaser.yml: migrate to new docker.ids

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,9 +20,7 @@ archives:
 dockers:
   - goos: linux
     goarch: amd64
-    builds:
-      - sloop
-    binaries:
+    ids:
       - sloop
     extra_files:
       - pkg/sloop/webserver/webfiles


### PR DESCRIPTION
Both [`docker.builds`](https://goreleaser.com/deprecations/#dockerbuilds) and [`docker.binaries`](https://goreleaser.com/deprecations/#dockerbinaries) were deprecated in favor of `docker.ids`. Without this, `make docker` fails with the latest version of `goreleaser`.