### PR TITLE
Handle ListenAndServe error

### DIFF
--- a/pkg/sloop/webserver/webserver.go
+++ b/pkg/sloop/webserver/webserver.go
@@ -232,7 +232,12 @@ func Run(config WebConfig, tables typed.Tables) error {
 
 	stop := make(chan os.Signal, 1)
 
-	go func() { _ = h.ListenAndServe() }()
+	go func() {
+		err := h.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
+			glog.Fatal(err)
+		}
+	}()
 
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 	<-stop


### PR DESCRIPTION
## Why

`h.ListenAndServe()` was swallowing errors, which can cause problems if the server can't start. For example, I had something else listening on Port 8080, but Sloop still said `Listening on http://localhost:8080` without showing any problems. 

## What
This handles errors from `h.ListenAndServe()`  and fails fast with a fatal log, which is probably the most pragmatic thing to do in this situation on start up without getting into goroutine error handling. It excludes `http.ErrServerClosed` as per the [docs](https://pkg.go.dev/net/http#Server.ListenAndServe):

> `ListenAndServe` always returns a non-nil error. After Shutdown or Close, the returned error is `ErrServerClosed`.

## Demo

### With port conflict

Listen on ipv6 port 8080 (e.g. `nc -l 8080 -6`) elsewhere and start Sloop:

```
I0223 10:56:49.985083   72374 webserver.go:230] Listening on http://localhost:8080
F0223 10:56:49.985439   72374 webserver.go:238] listen tcp :8080: bind: address already in use
goroutine 37165 [running]:
...
```

### Without port conflict and graceful shutdown

```
I0223 11:10:42.786731   73802 webserver.go:230] Listening on http://localhost:8080
^C
I0223 11:10:45.809332   73802 webserver.go:244] Shutting down server...
```