### PR TITLE
Switch to all-in-1/selfcontained docker builds and GH actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
+Dockerfile
 data/
 .git/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,47 @@
+name: build and publish container image
+on:
+  push:
+    branches:
+      - 'master'  
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:       
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ github.repository }}
+  
+
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+
+      - name: Build container image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          file: Dockerfile
+          tags:  ${{ steps.meta.outputs.tags  }}
+
+
+
+            

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,20 @@
-FROM alpine as build
-RUN apk add --no-cache curl
+FROM golang:1.16 as build
+RUN apt-get update && apt-get  install curl make
 RUN curl -o /aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/aws-iam-authenticator \
   && wait \
   && chmod +x /aws-iam-authenticator
 
+COPY . /build/
+WORKDIR /build
+
+RUN go env -w GO111MODULE=auto \
+   && make
+
+
+
+
 FROM gcr.io/distroless/base
-COPY sloop /sloop
+COPY --from=build /go/bin/sloop /sloop
 # The copy statement below can be uncommented to reflect changes to any webfiles as compared
 # to the binary version of the files in use.
 # COPY pkg/sloop/webserver/webfiles /webfiles


### PR DESCRIPTION
Use github actions to auto build and publish images to ghcr.io container image repo