### PR TITLE
Disable Granular metrics in default settings

### DIFF
--- a/pkg/sloop/server/internal/config/config.go
+++ b/pkg/sloop/server/internal/config/config.go
@@ -172,7 +172,7 @@ func getDefaultConfig() *SloopConfig {
 		BadgerVLogFileIOMapping:  false,
 		BadgerVLogTruncate:       true,
 		EnableDeleteKeys:         false,
-		EnableGranularMetrics:    true,
+		EnableGranularMetrics:    false,
 		BadgerDetailLogEnabled:   false,
 	}
 	return &defaultConfig


### PR DESCRIPTION
Disabling the granular metric by default as it might not be needed by all users in default mode and it can cause a lot of metrics data in Prometheus.