### PR TITLE
Allow specifying pod labels and annotations in Helm chart

### DIFF
--- a/helm/sloop/templates/statefulset.yaml
+++ b/helm/sloop/templates/statefulset.yaml
@@ -18,6 +18,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ .Values.name }}
         app.kubernetes.io/instance: "{{ .Release.Name }}"
+{{ toYaml .Values.podLabels | indent 8 }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}

--- a/helm/sloop/values.yaml
+++ b/helm/sloop/values.yaml
@@ -1,6 +1,9 @@
 serviceAccountName: sloop
 ## If defined, specifies the tolerations to attach to the pods
 tolerations: []
+## If defined, specifies the labels and/or annotations to attach to the pods
+podLabels: {}
+podAnnotations: {}
 name: sloop
 replicas: 1
 image:


### PR DESCRIPTION
Similarly to #225, this allows to add metadata to the created pods, which can be useful for e.g. network policies.