### PR TITLE
Fix YAML parsing following podLabels change

### DIFF
--- a/helm/sloop/templates/statefulset.yaml
+++ b/helm/sloop/templates/statefulset.yaml
@@ -18,7 +18,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ .Values.name }}
         app.kubernetes.io/instance: "{{ .Release.Name }}"
-{{ toYaml .Values.podLabels | indent 8 }}
+        {{- with .Values.podLabels -}}
+          {{ toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     spec:


### PR DESCRIPTION
Fixes #230, a bug introduced by #229.

Validated with `helm lint .`, `helm template .` and `helm template . --set podLabels.foo=bar`.
