### PR TITLE
Don't run middlewares on /healthz and /metrics endpoints

### DIFF
--- a/pkg/sloop/ingress/kubewatcher_test.go
+++ b/pkg/sloop/ingress/kubewatcher_test.go
@@ -51,10 +51,11 @@ func reactionError(_ k8sTesting.Action) (bool, runtime.Object, error) {
 }
 
 // newTestCrdClient - provides a function pointer to create a fake clientset
-//   takes: k8sTesting.Action function pointer - adds the reaction to the fake clientset
-//   returns a function pointer
-//      takes: restConfig
-//      returns: clientset.Interface & error (always nil)
+//
+//	takes: k8sTesting.Action function pointer - adds the reaction to the fake clientset
+//	returns a function pointer
+//	   takes: restConfig
+//	   returns: clientset.Interface & error (always nil)
 func newTestCrdClient(reaction func(_ k8sTesting.Action) (bool, runtime.Object, error)) func(_ *rest.Config) (clientset.Interface, error) {
 	return func(_ *rest.Config) (clientset.Interface, error) {
 		crdClient := &clientsetFake.Clientset{}

--- a/pkg/sloop/queries/respayloadquery.go
+++ b/pkg/sloop/queries/respayloadquery.go
@@ -110,7 +110,7 @@ func GetSeekKey(keyComparator *typed.WatchTableKey, startTime time.Time) *typed.
 	return seekKey
 }
 
-//todo: add unit tests
+// todo: add unit tests
 func getKeyComparator(params url.Values) *typed.WatchTableKey {
 	selectedNamespace := params.Get(NamespaceParam)
 	selectedName := params.Get(NameParam)
@@ -121,7 +121,7 @@ func getKeyComparator(params url.Values) *typed.WatchTableKey {
 	return typed.NewWatchTableKeyComparator(selectedKind, selectedNamespace, selectedName, time.Time{})
 }
 
-//todo: add unit tests
+// todo: add unit tests
 func getPayloadOutputList(watchRes map[typed.WatchTableKey]*typed.KubeWatchResult) []PayloadOuput {
 
 	payloadOutputList := []PayloadOuput{}

--- a/pkg/sloop/queries/timerange.go
+++ b/pkg/sloop/queries/timerange.go
@@ -24,14 +24,14 @@ const minLookback = 1 * time.Minute
 //
 // Using "lookback":
 //
-//   We first find the endTime.  If we are looking at historic data, we use the end of the last partitions.  If
-//   that is in the future, we use now().  We don't want to always use now() as that would prevent users from looking
-//   at old data as it would get clipped by maxLookBack
-//   StartTime is just endTime - lookback
+//	We first find the endTime.  If we are looking at historic data, we use the end of the last partitions.  If
+//	that is in the future, we use now().  We don't want to always use now() as that would prevent users from looking
+//	at old data as it would get clipped by maxLookBack
+//	StartTime is just endTime - lookback
 //
 // Using "start_time" and "end_time"
 //
-//   This is straight forward.  These are UTC Unix times
+//	This is straight forward.  These are UTC Unix times
 //
 // TODO: If wall clock is in the middle of the newest partition min-max time we can use it
 func computeTimeRange(params url.Values, tables typed.Tables, maxLookBack time.Duration) (time.Time, time.Time, error) {

--- a/pkg/sloop/store/typed/eventcounttable.go
+++ b/pkg/sloop/store/typed/eventcounttable.go
@@ -54,7 +54,7 @@ func (k *EventCountKey) Parse(key string) error {
 	return nil
 }
 
-//todo: need to make sure it can work as keyPrefix when some fields are empty
+// todo: need to make sure it can work as keyPrefix when some fields are empty
 func (k *EventCountKey) String() string {
 	if k.Uid == "" {
 		return fmt.Sprintf("/%v/%v/%v/%v/%v", k.TableName(), k.PartitionId, k.Kind, k.Namespace, k.Name)

--- a/pkg/sloop/store/typed/eventcounttablegen.go
+++ b/pkg/sloop/store/typed/eventcounttablegen.go
@@ -293,7 +293,7 @@ func (t *ResourceEventCountsTable) RangeRead(txn badgerwrap.Txn, keyPrefix *Even
 	return resources, stats, nil
 }
 
-//todo: need to add unit test
+// todo: need to add unit test
 func (t *ResourceEventCountsTable) GetPartitionsFromTimeRange(txn badgerwrap.Txn, startTime time.Time, endTime time.Time) ([]string, error) {
 	resources := []string{}
 	startPartition := untyped.GetPartitionId(startTime)

--- a/pkg/sloop/store/typed/resourcesummarytable.go
+++ b/pkg/sloop/store/typed/resourcesummarytable.go
@@ -60,7 +60,7 @@ func (k *ResourceSummaryKey) Parse(key string) error {
 	return nil
 }
 
-//todo: need to make sure it can work as keyPrefix when some fields are empty
+// todo: need to make sure it can work as keyPrefix when some fields are empty
 func (k *ResourceSummaryKey) String() string {
 	if k.Uid == "" {
 		return fmt.Sprintf("/%v/%v/%v/%v/%v", k.TableName(), k.PartitionId, k.Kind, k.Namespace, k.Name)

--- a/pkg/sloop/store/typed/resourcesummarytablegen.go
+++ b/pkg/sloop/store/typed/resourcesummarytablegen.go
@@ -293,7 +293,7 @@ func (t *ResourceSummaryTable) RangeRead(txn badgerwrap.Txn, keyPrefix *Resource
 	return resources, stats, nil
 }
 
-//todo: need to add unit test
+// todo: need to add unit test
 func (t *ResourceSummaryTable) GetPartitionsFromTimeRange(txn badgerwrap.Txn, startTime time.Time, endTime time.Time) ([]string, error) {
 	resources := []string{}
 	startPartition := untyped.GetPartitionId(startTime)

--- a/pkg/sloop/store/typed/tabletemplate.go
+++ b/pkg/sloop/store/typed/tabletemplate.go
@@ -275,7 +275,7 @@ func (t *ValueTypeTable) RangeRead(txn badgerwrap.Txn, keyPrefix *KeyType,
 	return resources, stats, nil
 }
 
-//todo: need to add unit test
+// todo: need to add unit test
 func (t *ValueTypeTable) GetPartitionsFromTimeRange(txn badgerwrap.Txn, startTime time.Time, endTime time.Time) ([]string, error) {
 	resources := []string{}
 	startPartition := untyped.GetPartitionId(startTime)

--- a/pkg/sloop/store/typed/watchactivitytable.go
+++ b/pkg/sloop/store/typed/watchactivitytable.go
@@ -58,7 +58,7 @@ func (k *WatchActivityKey) Parse(key string) error {
 	return nil
 }
 
-//todo: need to make sure it can work as keyPrefix when some fields are empty
+// todo: need to make sure it can work as keyPrefix when some fields are empty
 func (k *WatchActivityKey) String() string {
 	return fmt.Sprintf("/%v/%v/%v/%v/%v/%v", k.TableName(), k.PartitionId, k.Kind, k.Namespace, k.Name, k.Uid)
 }

--- a/pkg/sloop/store/typed/watchactivitytablegen.go
+++ b/pkg/sloop/store/typed/watchactivitytablegen.go
@@ -293,7 +293,7 @@ func (t *WatchActivityTable) RangeRead(txn badgerwrap.Txn, keyPrefix *WatchActiv
 	return resources, stats, nil
 }
 
-//todo: need to add unit test
+// todo: need to add unit test
 func (t *WatchActivityTable) GetPartitionsFromTimeRange(txn badgerwrap.Txn, startTime time.Time, endTime time.Time) ([]string, error) {
 	resources := []string{}
 	startPartition := untyped.GetPartitionId(startTime)

--- a/pkg/sloop/store/typed/watchtable.go
+++ b/pkg/sloop/store/typed/watchtable.go
@@ -78,7 +78,7 @@ func (k *WatchTableKey) IsNameAlreadyDelimited() bool {
 	return false
 }
 
-//todo: need to make sure it can work as keyPrefix when some fields are empty
+// todo: need to make sure it can work as keyPrefix when some fields are empty
 func (k *WatchTableKey) String() string {
 	if k.Name == "" && k.Timestamp.IsZero() {
 		return fmt.Sprintf("/%v/%v/%v/%v/", k.TableName(), k.PartitionId, k.Kind, k.Namespace)

--- a/pkg/sloop/store/typed/watchtablegen.go
+++ b/pkg/sloop/store/typed/watchtablegen.go
@@ -293,7 +293,7 @@ func (t *KubeWatchResultTable) RangeRead(txn badgerwrap.Txn, keyPrefix *WatchTab
 	return resources, stats, nil
 }
 
-//todo: need to add unit test
+// todo: need to add unit test
 func (t *KubeWatchResultTable) GetPartitionsFromTimeRange(txn badgerwrap.Txn, startTime time.Time, endTime time.Time) ([]string, error) {
 	resources := []string{}
 	startPartition := untyped.GetPartitionId(startTime)

--- a/pkg/sloop/webserver/bindata.go
+++ b/pkg/sloop/webserver/bindata.go
@@ -413,31 +413,33 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"webfiles/debug.html": webfilesDebugHtml,
-	"webfiles/debug.js": webfilesDebugJs,
-	"webfiles/debugconfig.html": webfilesDebugconfigHtml,
+	"webfiles/debug.html":          webfilesDebugHtml,
+	"webfiles/debug.js":            webfilesDebugJs,
+	"webfiles/debugconfig.html":    webfilesDebugconfigHtml,
 	"webfiles/debughistogram.html": webfilesDebughistogramHtml,
-	"webfiles/debuglistkeys.html": webfilesDebuglistkeysHtml,
-	"webfiles/debugtables.html": webfilesDebugtablesHtml,
-	"webfiles/debugviewkey.html": webfilesDebugviewkeyHtml,
-	"webfiles/favicon.ico": webfilesFaviconIco,
-	"webfiles/filter.js": webfilesFilterJs,
-	"webfiles/index.html": webfilesIndexHtml,
-	"webfiles/resource.css": webfilesResourceCss,
-	"webfiles/resource.html": webfilesResourceHtml,
-	"webfiles/sloop.css": webfilesSloopCss,
-	"webfiles/sloop_ui.js": webfilesSloop_uiJs,
+	"webfiles/debuglistkeys.html":  webfilesDebuglistkeysHtml,
+	"webfiles/debugtables.html":    webfilesDebugtablesHtml,
+	"webfiles/debugviewkey.html":   webfilesDebugviewkeyHtml,
+	"webfiles/favicon.ico":         webfilesFaviconIco,
+	"webfiles/filter.js":           webfilesFilterJs,
+	"webfiles/index.html":          webfilesIndexHtml,
+	"webfiles/resource.css":        webfilesResourceCss,
+	"webfiles/resource.html":       webfilesResourceHtml,
+	"webfiles/sloop.css":           webfilesSloopCss,
+	"webfiles/sloop_ui.js":         webfilesSloop_uiJs,
 }
 
 // AssetDir returns the file names below a certain
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error
@@ -468,22 +470,23 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
 	"webfiles": &bintree{nil, map[string]*bintree{
-		"debug.html": &bintree{webfilesDebugHtml, map[string]*bintree{}},
-		"debug.js": &bintree{webfilesDebugJs, map[string]*bintree{}},
-		"debugconfig.html": &bintree{webfilesDebugconfigHtml, map[string]*bintree{}},
+		"debug.html":          &bintree{webfilesDebugHtml, map[string]*bintree{}},
+		"debug.js":            &bintree{webfilesDebugJs, map[string]*bintree{}},
+		"debugconfig.html":    &bintree{webfilesDebugconfigHtml, map[string]*bintree{}},
 		"debughistogram.html": &bintree{webfilesDebughistogramHtml, map[string]*bintree{}},
-		"debuglistkeys.html": &bintree{webfilesDebuglistkeysHtml, map[string]*bintree{}},
-		"debugtables.html": &bintree{webfilesDebugtablesHtml, map[string]*bintree{}},
-		"debugviewkey.html": &bintree{webfilesDebugviewkeyHtml, map[string]*bintree{}},
-		"favicon.ico": &bintree{webfilesFaviconIco, map[string]*bintree{}},
-		"filter.js": &bintree{webfilesFilterJs, map[string]*bintree{}},
-		"index.html": &bintree{webfilesIndexHtml, map[string]*bintree{}},
-		"resource.css": &bintree{webfilesResourceCss, map[string]*bintree{}},
-		"resource.html": &bintree{webfilesResourceHtml, map[string]*bintree{}},
-		"sloop.css": &bintree{webfilesSloopCss, map[string]*bintree{}},
-		"sloop_ui.js": &bintree{webfilesSloop_uiJs, map[string]*bintree{}},
+		"debuglistkeys.html":  &bintree{webfilesDebuglistkeysHtml, map[string]*bintree{}},
+		"debugtables.html":    &bintree{webfilesDebugtablesHtml, map[string]*bintree{}},
+		"debugviewkey.html":   &bintree{webfilesDebugviewkeyHtml, map[string]*bintree{}},
+		"favicon.ico":         &bintree{webfilesFaviconIco, map[string]*bintree{}},
+		"filter.js":           &bintree{webfilesFilterJs, map[string]*bintree{}},
+		"index.html":          &bintree{webfilesIndexHtml, map[string]*bintree{}},
+		"resource.css":        &bintree{webfilesResourceCss, map[string]*bintree{}},
+		"resource.html":       &bintree{webfilesResourceHtml, map[string]*bintree{}},
+		"sloop.css":           &bintree{webfilesSloopCss, map[string]*bintree{}},
+		"sloop_ui.js":         &bintree{webfilesSloop_uiJs, map[string]*bintree{}},
 	}},
 }}
 
@@ -533,4 +536,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-

--- a/pkg/sloop/webserver/weblogging.go
+++ b/pkg/sloop/webserver/weblogging.go
@@ -10,9 +10,10 @@ package webserver
 import (
 	"context"
 	"fmt"
-	"github.com/golang/glog"
 	"net/http"
 	"time"
+
+	"github.com/golang/glog"
 )
 
 const requestIDKey string = "reqId"
@@ -45,7 +46,7 @@ func glogWrapper(handler http.Handler) http.Handler {
 		before := time.Now()
 		handler.ServeHTTP(w, r)
 		requestID := getRequestId(r.Context())
-		var timeTaken = time.Since(before)
+		timeTaken := time.Since(before)
 		metricWebServerRequestLatency.Set(timeTaken.Seconds())
 		glog.Infof("reqId: %v http url: %v took: %v remote: %v useragent: %v", requestID, r.URL, timeTaken, r.RemoteAddr, r.UserAgent())
 	})

--- a/pkg/sloop/webserver/webserver.go
+++ b/pkg/sloop/webserver/webserver.go
@@ -200,12 +200,6 @@ func registerPaths(router *mux.Router, config WebConfig, tables typed.Tables) {
 	router.HandleFunc("/debug/vars", expvar.Handler().ServeHTTP)
 	router.HandleFunc("/debug/", debugHandler())
 
-	router.Handle("/metrics", promhttp.HandlerFor(
-		prometheus.DefaultGatherer,
-		promhttp.HandlerOpts{
-			EnableOpenMetrics: true,
-		},
-	))
 	router.Handle("", indexHandler(config))
 }
 
@@ -215,6 +209,12 @@ func Run(config WebConfig, tables typed.Tables) error {
 	server.mux = mux.NewRouter()
 	server.mux.Handle("/", traceWrapper(glogWrapper(redirectHandler(config.CurrentContext))))
 	server.mux.Handle("/healthz", healthHandler())
+	server.mux.Handle("/metrics", promhttp.HandlerFor(
+		prometheus.DefaultGatherer,
+		promhttp.HandlerOpts{
+			EnableOpenMetrics: true,
+		},
+	))
 	subMux := server.mux.PathPrefix("/{clusterContext}").Subrouter()
 	registerPaths(subMux, config, tables)
 	subMux.Use(traceWrapper)


### PR DESCRIPTION
This reduces noise in logs generated by Kubernetes liveness probe and Prometheus scrape requests.
It also prevents incrementing the shared `sloop_webserver_request_count` metric that doesn't have labels to distinguish healthz or metrics traffic. 
Ideally we would use a histogram with path labels for http server request metrics. Perhaps in a future PR.

Additionally `X-Request-Id` is no longer copied into the `context` as it is no longer used (logged).