### PR TITLE
feat(metrics): Add HTTP RED metrics and remove gorilla/mux

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.4.3
 	github.com/googleapis/gnostic v0.3.1 // indirect
-	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/jteeuwen/go-bindata v3.0.7+incompatible

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,7 @@ github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEg
 github.com/Azure/go-autorest/autorest/date v0.1.0 h1:YGrhWfrgtFs84+h0o46rJrlmsZtyZRg470CqAXTZaGM=
 github.com/Azure/go-autorest/autorest/date v0.1.0/go.mod h1:plvfp3oPSKwf2DNjlBjWF/7vwR+cUD/ELuzDCXwHUVA=
 github.com/Azure/go-autorest/autorest/mocks v0.1.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
+github.com/Azure/go-autorest/autorest/mocks v0.2.0 h1:Ww5g4zThfD/6cLb4z6xxgeyDa7QDkizMkJKe0ysZXp0=
 github.com/Azure/go-autorest/autorest/mocks v0.2.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
 github.com/Azure/go-autorest/logger v0.1.0 h1:ruG4BSDXONFRrZZJ2GUXDiUyVpayPmb1GnWeHDdaNKY=
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=
@@ -210,8 +211,6 @@ github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsC
 github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJhYk=
 github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
-github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
-github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/pkg/sloop/webserver/middleware.go
+++ b/pkg/sloop/webserver/middleware.go
@@ -85,7 +85,7 @@ func middlewareChain(handlerName string, next http.Handler) http.HandlerFunc {
 	)
 }
 
-func metricCountsMiddleware(handlerName string, next http.Handler) http.HandlerFunc {
+func metricCountMiddleware(handlerName string, next http.Handler) http.HandlerFunc {
 	return promhttp.InstrumentHandlerCounter(
 		metricWebServerRequestCount.MustCurryWith(prometheus.Labels{"handler": handlerName}), next)
 }

--- a/pkg/sloop/webserver/middleware.go
+++ b/pkg/sloop/webserver/middleware.go
@@ -15,10 +15,29 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const requestIDKey string = "reqId"
+
+var (
+	metricWebServerRequestCount = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "sloop_http_requests_total",
+			Help: "A counter for requests to the wrapped handler.",
+		},
+		[]string{"code", "handler"},
+	)
+	metricWebServerRequestDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "sloop_http_request_duration_seconds",
+			Help:    "A histogram of latencies for requests to the wrapped handler.",
+			Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60},
+		},
+		[]string{"handler"},
+	)
+)
 
 func getRequestId(webContext context.Context) string {
 	requestID, ok := webContext.Value(requestIDKey).(string)
@@ -29,7 +48,7 @@ func getRequestId(webContext context.Context) string {
 }
 
 // Sets a request id in the context which can be used for logging
-func traceWrapper(next http.Handler) http.Handler {
+func traceMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestID := r.Header.Get("X-Request-Id")
 		if requestID == "" {
@@ -42,7 +61,7 @@ func traceWrapper(next http.Handler) http.Handler {
 }
 
 // Logs all HTTP requests to glog
-func glogWrapper(next http.Handler) http.Handler {
+func glogMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		before := time.Now()
 		next.ServeHTTP(w, r)
@@ -52,13 +71,13 @@ func glogWrapper(next http.Handler) http.Handler {
 	})
 }
 
-func wrapperChain(handler string, next http.Handler) http.HandlerFunc {
+func middlewareChain(handlerName string, next http.Handler) http.HandlerFunc {
 	return promhttp.InstrumentHandlerCounter(
-		metricWebServerRequestCount.MustCurryWith(prometheus.Labels{"handler": handler}),
+		metricWebServerRequestCount.MustCurryWith(prometheus.Labels{"handler": handlerName}),
 		promhttp.InstrumentHandlerDuration(
-			metricWebServerRequestDuration.MustCurryWith(prometheus.Labels{"handler": handler}),
-			traceWrapper(
-				glogWrapper(
+			metricWebServerRequestDuration.MustCurryWith(prometheus.Labels{"handler": handlerName}),
+			traceMiddleware(
+				glogMiddleware(
 					next,
 				),
 			),
@@ -66,7 +85,7 @@ func wrapperChain(handler string, next http.Handler) http.HandlerFunc {
 	)
 }
 
-func metricCountsWrapper(handler string, next http.Handler) http.HandlerFunc {
+func metricCountsMiddleware(handlerName string, next http.Handler) http.HandlerFunc {
 	return promhttp.InstrumentHandlerCounter(
-		metricWebServerRequestCount.MustCurryWith(prometheus.Labels{"handler": handler}), next)
+		metricWebServerRequestCount.MustCurryWith(prometheus.Labels{"handler": handlerName}), next)
 }

--- a/pkg/sloop/webserver/webfiles/debug.html
+++ b/pkg/sloop/webserver/webfiles/debug.html
@@ -13,7 +13,7 @@ For full license text, see LICENSE.txt file in the repo root or https://opensour
     <title>Sloop Debug Menu</title>
     <link rel='shortcut icon' type='image/x-icon' href='webfiles/favicon.ico' />
 </head>
-<body onload="loadHomeRef();"> 
+<body onload="loadHomeRef();">
 [ <a id="homeLink">Home</a> ]
 
 <h2>Sloop Debug Menu</h2>
@@ -26,7 +26,7 @@ For full license text, see LICENSE.txt file in the repo root or https://opensour
     <li><a href="debug/requests">Badger Requests</a></li>
     <li><a href="debug/events">Badger Events</a></li>
     <li><a href="debug/vars">Badger Metrics</a></li>
-    <li><a href="metrics">Sloop Metrics</a></li>
+    <li><a href="/metrics">Sloop Metrics</a></li>
 </ul>
 
 </body>

--- a/pkg/sloop/webserver/weblogging.go
+++ b/pkg/sloop/webserver/weblogging.go
@@ -52,19 +52,21 @@ func glogWrapper(next http.Handler) http.Handler {
 	})
 }
 
-func metricCountsDurationsWrapperChain(handler string, next http.Handler) http.HandlerFunc {
+func wrapperChain(handler string, next http.Handler) http.HandlerFunc {
 	return promhttp.InstrumentHandlerCounter(
 		metricWebServerRequestCount.MustCurryWith(prometheus.Labels{"handler": handler}),
 		promhttp.InstrumentHandlerDuration(
-			metricWebServerRequestDuration.MustCurryWith(prometheus.Labels{"handler": handler}), next))
+			metricWebServerRequestDuration.MustCurryWith(prometheus.Labels{"handler": handler}),
+			traceWrapper(
+				glogWrapper(
+					next,
+				),
+			),
+		),
+	)
 }
 
 func metricCountsWrapper(handler string, next http.Handler) http.HandlerFunc {
 	return promhttp.InstrumentHandlerCounter(
 		metricWebServerRequestCount.MustCurryWith(prometheus.Labels{"handler": handler}), next)
-}
-
-func metricDurationsWrapper(handler string, next http.Handler) http.HandlerFunc {
-	return promhttp.InstrumentHandlerDuration(
-		metricWebServerRequestDuration.MustCurryWith(prometheus.Labels{"handler": handler}), next)
 }

--- a/pkg/sloop/webserver/webserver.go
+++ b/pkg/sloop/webserver/webserver.go
@@ -175,8 +175,8 @@ func registerRoutes(mux *http.ServeMux, config WebConfig, tables typed.Tables) {
 	// root pages
 	mux.Handle("/", middlewareChain("root", redirectHandler(config.CurrentContext)))
 	// Only metric on endpoints scraped by bots to avoid noise in logs.
-	mux.Handle("/healthz", metricCountsMiddleware("healthz", healthHandler()))
-	mux.Handle("/metrics", metricCountsMiddleware("metrics", promhttp.HandlerFor(
+	mux.Handle("/healthz", metricCountMiddleware("healthz", healthHandler()))
+	mux.Handle("/metrics", metricCountMiddleware("metrics", promhttp.HandlerFor(
 		prometheus.DefaultGatherer,
 		promhttp.HandlerOpts{
 			EnableOpenMetrics: true,

--- a/pkg/sloop/webserver/webserver.go
+++ b/pkg/sloop/webserver/webserver.go
@@ -67,14 +67,14 @@ type WebConfig struct {
 var (
 	metricWebServerRequestCount = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "sloop_webserver_http_requests_total",
+			Name: "sloop_http_requests_total",
 			Help: "A counter for requests to the wrapped handler.",
 		},
 		[]string{"code", "handler"},
 	)
 	metricWebServerRequestDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "sloop_webserver_http_request_duration_seconds",
+			Name:    "sloop_http_request_duration_seconds",
 			Help:    "A histogram of latencies for requests to the wrapped handler.",
 			Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60},
 		},

--- a/pkg/sloop/webserver/webserver.go
+++ b/pkg/sloop/webserver/webserver.go
@@ -179,7 +179,12 @@ func healthHandler() http.HandlerFunc {
 // Handler for redirecting / to /currentContext to ensure backward compatibility
 func redirectHandler(currentContext string) http.HandlerFunc {
 	return func(writer http.ResponseWriter, request *http.Request) {
-		redirectURL := path.Join("/", currentContext, request.URL.Path)
+		if request.URL.Path != "/" {
+			writer.WriteHeader(http.StatusNotFound)
+			writer.Write([]byte(http.StatusText(http.StatusNotFound)))
+			return
+		}
+		redirectURL := path.Join("/", currentContext)
 		http.Redirect(writer, request, redirectURL, http.StatusTemporaryRedirect)
 	}
 }

--- a/pkg/sloop/webserver/webserver_test.go
+++ b/pkg/sloop/webserver/webserver_test.go
@@ -1,23 +1,46 @@
 package webserver
 
 import (
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRedirectHandlerHandler(t *testing.T) {
-	req, err := http.NewRequest("GET", "/", nil)
-	assert.Nil(t, err)
+	testCases := map[string]struct {
+		url      string
+		code     int
+		location string
+	}{
+		"successfully redirect on /": {
+			"/",
+			http.StatusTemporaryRedirect,
+			"/clusterContext",
+		},
+		"return 404 for invalid url": {
+			"/an-invalid-url",
+			http.StatusNotFound,
+			"",
+		},
+	}
 
-	// Create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
-	rr := httptest.NewRecorder()
-	handler := http.HandlerFunc(redirectHandler("clusterContext"))
-	handler.ServeHTTP(rr, req)
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			req, err := http.NewRequest("GET", tc.url, nil)
+			assert.Nil(t, err)
+			// Create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+			rr := httptest.NewRecorder()
+			handler := http.HandlerFunc(redirectHandler("clusterContext"))
+			handler.ServeHTTP(rr, req)
 
-	assert.Equal(t, http.StatusTemporaryRedirect, rr.Code)
-	assert.Equal(t, "/clusterContext", rr.Result().Header["Location"][0])
+			assert.Equal(t, tc.code, rr.Code)
+			if len(tc.location) > 0 {
+				assert.Equal(t, tc.location, rr.Result().Header["Location"][0])
+			}
+		})
+	}
 }
 
 func TestWebFileHandler(t *testing.T) {


### PR DESCRIPTION
- update `/debug` landing page to correct /metrics URL
- add HTTP request duration and counter metrics per handler. Note durations aggregate all response codes to minimise cardinality
- remove `gorilla/mux` dependency to simplify route configuration and project has been seeking a maintainer for some time
- don't blindly prefix unhandled paths with Kubernetes current context value, e.g: `/not-a-handled-path` should return a 404. 

Note that some handlers return a 500 when it is more of a client error (missing query params).
Invalid/incorrect `webfiles` such as `/<context>/webfiles/not-a-real-file.css` also return 500's instead of 404. This is unchanged in this PR and something for later.