### PR TITLE
Fix publish GHA CI - Arm32 doesn't support Go race detector

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,21 +1,21 @@
-name: build and publish container image
+name: Publish
 on:
   push:
     branches:
-      - 'master'  
+      - 'master'
     tags:
       - 'v*'
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    steps:       
+    steps:
       - name: Check out the repo
         uses: actions/checkout@v2
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -32,7 +32,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
-  
+
       - name: Log in to GitHub Docker Registry
         uses: docker/login-action@v1
         with:
@@ -47,7 +47,3 @@ jobs:
           platforms: linux/amd64,linux/arm64, linux/arm
           file: Dockerfile
           tags:  ${{ steps.meta.outputs.tags  }}
-
-
-
-            

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Format, lint and test
+name: Test
 
 on:
   push:
@@ -46,3 +46,6 @@ jobs:
         run: |
           go mod tidy
           git diff --exit-code -- go.mod go.sum || true
+
+      - name: Run go build
+        run: go build ./pkg/sloop/main.go

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ all:
 	go get ./pkg/...
 	go fmt ./pkg/...
 	go install ./pkg/...
-	go test -race -cover ./pkg/...
+	go test -cover ./pkg/...
 
-run: 
+run:
 	go install ./pkg/...
 	$(GOPATH)/bin/sloop
 
@@ -37,7 +37,7 @@ protobuf:
 	protoc -I=./pkg/sloop/store/typed/ --go_out=./pkg/sloop/store/typed/ ./pkg/sloop/store/typed/schema.proto
 
 cover:
-	go test -race ./pkg/... -coverprofile=coverage.out
+	go test ./pkg/... -coverprofile=coverage.out
 	go tool cover -html=coverage.out
 
 release:

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Sloop - Kubernetes History Visualization
 
-[![Build Status](https://travis-ci.org/salesforce/sloop.svg?branch=master)](https://travis-ci.org/salesforce/sloop)
+[![Publish Status](https://github.com/salesforce/sloop/workflows/Publish/badge.svg)](https://github.com/salesforce/sloop/actions)
+[![Build Status](https://github.com/salesforce/sloop/workflows/Test/badge.svg)](https://github.com/salesforce/sloop/actions)
 [![Go Report Card](https://goreportcard.com/badge/github.com/salesforce/sloop)](https://goreportcard.com/report/github.com/salesforce/sloop)
-![Docker Pulls](https://img.shields.io/docker/pulls/sloopimage/sloop)
 
 <img src="https://github.com/salesforce/sloop/raw/master/other/sloop_logo_color_small_notext.png">
 
-----
+---
 
-Sloop monitors Kubernetes, recording histories of events and resource state changes 
-and providing visualizations to aid in debugging past events.  
+Sloop monitors Kubernetes, recording histories of events and resource state changes
+and providing visualizations to aid in debugging past events.
 
 Key features:
 
@@ -19,7 +19,7 @@ Key features:
 1. Allows you to see changes over time in a Kubernetes application.
 1. Is a self-contained service with no dependencies on distributed storage.
 
-----
+---
 
 ## Screenshots
 
@@ -62,10 +62,10 @@ When complete, you should have a running Sloop version accessing the current con
 
 Other makefile targets:
 
-* *docker*: Builds a Docker image.
-* *cover*: Runs unit tests with code coverage.
-* *generate*: Updates genny templates for typed table classes.
-* *protobuf*: Generates protobuf code-gen.
+- _docker_: Builds a Docker image.
+- _cover_: Runs unit tests with code coverage.
+- _generate_: Updates genny templates for typed table classes.
+- _protobuf_: Generates protobuf code-gen.
 
 ### Local Docker Run
 
@@ -111,6 +111,7 @@ To restore from a backup, start `sloop` with the `-restore-database-file` flag s
 ## Memory Consumption
 
 Sloop's memory usage can be managed by tweaking several options:
+
 - `badger-use-lsm-only-options` If this flag is set to true, values would be collocated with the LSM tree, with value log largely acting as a write-ahead log only. Recommended value for memory constrained environments: false
 - `badger-keep-l0-in-memory` When this flag is set to true, Level 0 tables are kept in memory. This leads to better performance in writes as well as compactions. Recommended value for memory constrained environments: false
 - `badger-sync-writes` When SyncWrites is true all writes are synced to disk. Setting this to false would achieve better performance, but may cause data loss in case of crash. Recommended value for memory constrained environments: false
@@ -119,31 +120,37 @@ Sloop's memory usage can be managed by tweaking several options:
 Apart from these flags some other values can be tweaked to fit in the memory constraints. Following are some examples of setups.
 
 - Memory consumption max limit: 1GB
-``` 
-               // 0.5<<20 (524288 bytes = 0.5 Mb)               
+
+```
+               // 0.5<<20 (524288 bytes = 0.5 Mb)
                "badger-max-table-size=524288",
                "badger-number-of-compactors=1",
                "badger-number-of-level-zero-tables=1",
                "badger-number-of-zero-tables-stall=2",
 ```
+
 - Memory consumption max limit: 2GB
-``` 
-               // 16<<20 (16777216 bytes = 16 Mb)              
+
+```
+               // 16<<20 (16777216 bytes = 16 Mb)
                "badger-max-table-size=16777216",
                "badger-number-of-compactors=1",
                "badger-number-of-level-zero-tables=1",
                "badger-number-of-zero-tables-stall=2",
 ```
+
 - Memory consumption max limit: 5GB
-``` 
-               // 32<<20 (33554432 bytes = 32 Mb)             
+
+```
+               // 32<<20 (33554432 bytes = 32 Mb)
                "badger-max-table-size=33554432",
                "badger-number-of-compactors=1",
                "badger-number-of-level-zero-tables=2",
                "badger-number-of-zero-tables-stall=3",
 ```
 
-Apart from the above settings, max-disk-mb and max-look-back can be tweaked according to input data and memory constraints.  
+Apart from the above settings, max-disk-mb and max-look-back can be tweaked according to input data and memory constraints.
+
 ## Contributing
 
 Refer to [CONTRIBUTING.md](CONTRIBUTING.md)<br>


### PR DESCRIPTION
We still use `go test -race` in the `test.yml` GHA so will catch failures there.

Whilst in the area, change README from Travis to GHA based CI status.