### PR TITLE
Bump to Go 1.19 and clarify versioning policies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,23 @@
 ## Build
 
-Sloop uses GitHub to manage reviews of pull requests
-
-[Singing up for a GitHub account](https://docs.github.com/en/github/getting-started-with-github/signing-up-for-a-new-github-account) if you don't have one
-
-
+Sloop uses GitHub to manage contributions. You'll need to [sign up for a GitHub account](https://docs.github.com/en/github/getting-started-with-github/signing-up-for-a-new-github-account) if you don't have one.
 
 ## Steps to Contribute
 
-1.[Pick an issue you are interested in working on](https://github.com/salesforce/sloop/issues).
-It’s a good idea to comment on an Issue that you want to help with and ask some questions before doing any major coding work
+1. [Pick an issue you are interested in working on](https://github.com/salesforce/sloop/issues).
+   It’s a good idea to comment on an Issue that you want to help with and ask some questions before doing any major coding work
 
-2.Fork the repository: Look for the “Fork” button in the top right corner of [salesforce/sloop repo](https://github.com/salesforce/sloop)
+2. Fork the repository: Look for the “Fork” button in the top right corner of [salesforce/sloop repo](https://github.com/salesforce/sloop)
 
-3.Clone the fork: Click on the green “clone or download” button,you can choose “clone with HTTPS.” Or, you can use SSH, which is compatible with 2-factor authentication, but just [some more work to set up](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh).
-Go to the folder where you want to save the repository, type `git clone that-https-url-you-copied`
+3. Clone the fork: Click on the green “clone or download” button,you can choose “clone with HTTPS.” Or, you can use SSH, which is compatible with 2-factor authentication, but just [some more work to set up](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh).
+   Go to the folder where you want to save the repository, type `git clone that-https-url-you-copied`
 
-4: Add a remote pointing to the original repository so you can sync changes: `git remote add upstream git@github.com:salesforce/sloop.git`
+4. Add a remote pointing to the original repository so you can sync changes: `git remote add upstream git@github.com:salesforce/sloop.git`
 
-5.Make a git branch: If you type git status you will see the branch name that you’re on, called master. In most projects, master is a special place where the most stable, reviewed, up-to-date code is. So, you’ll need to make your own branch and switch to that branch:
-`git checkout -b name-for-your-branch`
+5. Make a git branch: If you type git status you will see the branch name that you’re on, called master. In most projects, master is a special place where the most stable, reviewed, up-to-date code is. So, you’ll need to make your own branch and switch to that branch:
+   `git checkout -b name-for-your-branch`
 
-6.Make some commits:
+6. Make some commits:
 
 When you have some code that you want to keep, you should save it in git by creating a commit. Here’s how:
 
@@ -35,31 +31,64 @@ When you have some code that you want to keep, you should save it in git by crea
 
 `git push origin name-for-your-branch` to save your work online
 
-7.Open a Pull Request: To create one, go to your fork of the project, click on the Pull Requests tab, and click the big green “New Pull Request” button. After you choose your branch,
-click the green “Create Pull Request” button. It will be super helpful if you can write a sentence or two summarizing the work you did and include a link to the Issue you were working on.
-If you are working on a new issue, please create one under Issues tab
+7. Open a Pull Request: To create one, go to your fork of the project, click on the Pull Requests tab, and click the big green “New Pull Request” button. After you choose your branch,
+   click the green “Create Pull Request” button. It will be super helpful if you can write a sentence or two summarizing the work you did and include a link to the Issue you were working on.
+   If you are working on a new issue, please create one under Issues tab
 
-8.Expect changes and be patient: Next up, a maintainer or contributor will review your code. Once your work is approved, it will be merged in!
-Congratulations and thank you for giving back to the open source community :) 
-
-
+8. Expect changes and be patient: Next up, a maintainer or contributor will review your code. Once your work is approved, it will be merged in!
+   Congratulations and thank you for giving back to the open source community :)
 
 ## Pull Request Checklist
-1.Design
 
-2.Functionality
+1. Design
 
-3.Tests
+2. Functionality
 
-4.Naming
+3. Tests
 
-5.Comments
+4. Naming
 
-## Dependency Management
+5. Comments
 
-Sloop uses [go modules](https://golang.org/cmd/go/#hdr-Modules__module_versions__and_more).  
-This requires a working Go environment with version 1.13 or greater installed.
-It is suggested you set `export GO111MODULE=on`
+## Versioning & Dependency Management
+
+### Go Version
+
+The Go Version required in Sloop is primarily influenced by two factors.
+
+Firstly, the Go project supports 2 versions at a time for bug fixes and
+vulnerability patching. We target the lowest supported version to maximise
+compatibility with users systems.
+
+Secondly, the Kubernetes client library used by Sloop for interacting with
+Kubernetes clusters defines its own required Go version.
+
+Sloop uses whichever of these two versions is the most recent.
+
+### Kubernetes client-go
+
+Sloop uses the [client-go](https://github.com/kubernetes/client-go) library for
+interacting with Kubernetes clusters.
+
+The Kubernetes project has its own release cadence and maintains support for
+each release for a period of time. This support includes fixing bugs and
+patching vulnerabilities.
+
+The Sloop project aims to only support Kubernetes releases that are currently
+maintained by the Kubernetes project. This is a sliding window of releases.
+
+When a new Kubernetes version is released it may require updating the Go
+version to support the new `client-go` version compatible with the Kubernetes
+API.
+
+It's possible that Sloop may continue to work for older end-of-life Kubernetes
+releases but that is outside of the Sloop project goals.
+
+### Go Modules
+
+Sloop uses [go modules](https://golang.org/cmd/go/#hdr-Modules__module_versions__and_more).
+This requires a working Go environment with the version defined in the
+[go.mod](./go.mod) file or greater installed.
 
 To add or update a new dependency:
 
@@ -70,21 +99,11 @@ To add or update a new dependency:
 
 When changing schema in pkg/sloop/store/typed/schema.proto you will need to do the following:
 
-1. Install protobuf.  On OSX you can do `brew install protobuf`
+1. Install protobuf. On OSX you can do `brew install protobuf`
 1. Grab protoc-gen-go with `go get -u github.com/golang/protobuf/protoc-gen-go`
 1. Run this makefile target: `make protobuf`
 
 ## Changes to Generated Code
 
-Sloop uses genny to code-gen typed table wrappers.  Any changes to `pkg/sloop/store/typed/tabletemplate*.go` will need 
-to be followed with `go generate`.  We have a Makefile target for this: `make generate`
-
-## Prometheus
-
-Sloop uses prometheus to emit metrics, which is very helpful for performance debugging.  In the root of the repo is a prometheus config.
-
-On OSX you can install prometheus with `brew install prometheus`.  Then simply start it from the sloop directory by running `prometheus`
-
-Open your browser to http://localhost:9090.  
- 
-An example of a useful query is [rate(kubewatch_event_count[5m])](http://localhost:9090/graph?g0.range_input=1h&g0.expr=rate(kubewatch_event_count%5B1m%5D)&g0.tab=0)
+Sloop uses genny to code-gen typed table wrappers. Any changes to `pkg/sloop/store/typed/tabletemplate*.go` will need
+to be followed with `go generate`. We have a Makefile target for this: `make generate`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM golang:1.16 as build
-RUN apt-get update && apt-get  install curl make
+FROM golang:1.19 as build
+RUN apt-get update && apt-get install curl make
+
+# https://github.com/kubernetes-sigs/aws-iam-authenticator/releases
 RUN curl -o /aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/aws-iam-authenticator \
   && wait \
   && chmod +x /aws-iam-authenticator
@@ -7,8 +9,7 @@ RUN curl -o /aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com
 COPY . /build/
 WORKDIR /build
 
-RUN go env -w GO111MODULE=auto \
-   && make
+RUN make
 
 FROM gcr.io/distroless/base
 COPY --from=build /go/bin/sloop /sloop

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 <img src="https://github.com/salesforce/sloop/raw/master/other/sloop_logo_color_small_notext.png">
 
-----
+---
 
-Sloop monitors Kubernetes, recording histories of events and resource state changes 
-and providing visualizations to aid in debugging past events.  
+Sloop monitors Kubernetes, recording histories of events and resource state changes
+and providing visualizations to aid in debugging past events.
 
 Key features:
 
@@ -19,7 +19,7 @@ Key features:
 1. Allows you to see changes over time in a Kubernetes application.
 1. Is a self-contained service with no dependencies on distributed storage.
 
-----
+---
 
 ## Screenshots
 
@@ -39,12 +39,14 @@ Users can install sloop by using helm chart now, for instructions refer [helm re
 
 ### Precompiled Binaries
 
-- Docker: [`sloopimage/sloop`](https://hub.docker.com/r/sloopimage/sloop)
+TODO: See the [Releases](https://github.com/salesforce/sloop/releases).
 
 ### Build from Source
 
 Building Sloop from source needs a working Go environment
-with [version 1.13 or greater installed](https://golang.org/doc/install).
+with the version defined in the [go.mod](./go.mod) file or greater.
+
+See: https://golang.org/doc/install
 
 Clone the sloop repository and build using `make`:
 
@@ -53,7 +55,6 @@ mkdir -p $GOPATH/src/github.com/salesforce
 cd $GOPATH/src/github.com/salesforce
 git clone https://github.com/salesforce/sloop.git
 cd sloop
-go env -w GO111MODULE=auto
 make
 $GOPATH/bin/sloop
 ```
@@ -62,10 +63,10 @@ When complete, you should have a running Sloop version accessing the current con
 
 Other makefile targets:
 
-* *docker*: Builds a Docker image.
-* *cover*: Runs unit tests with code coverage.
-* *generate*: Updates genny templates for typed table classes.
-* *protobuf*: Generates protobuf code-gen.
+- _docker_: Builds a Docker image.
+- _cover_: Runs unit tests with code coverage.
+- _generate_: Updates genny templates for typed table classes.
+- _protobuf_: Generates protobuf code-gen.
 
 ### Local Docker Run
 
@@ -111,6 +112,7 @@ To restore from a backup, start `sloop` with the `-restore-database-file` flag s
 ## Memory Consumption
 
 Sloop's memory usage can be managed by tweaking several options:
+
 - `badger-use-lsm-only-options` If this flag is set to true, values would be collocated with the LSM tree, with value log largely acting as a write-ahead log only. Recommended value for memory constrained environments: false
 - `badger-keep-l0-in-memory` When this flag is set to true, Level 0 tables are kept in memory. This leads to better performance in writes as well as compactions. Recommended value for memory constrained environments: false
 - `badger-sync-writes` When SyncWrites is true all writes are synced to disk. Setting this to false would achieve better performance, but may cause data loss in case of crash. Recommended value for memory constrained environments: false
@@ -119,31 +121,50 @@ Sloop's memory usage can be managed by tweaking several options:
 Apart from these flags some other values can be tweaked to fit in the memory constraints. Following are some examples of setups.
 
 - Memory consumption max limit: 1GB
-``` 
-               // 0.5<<20 (524288 bytes = 0.5 Mb)               
+
+```
+               // 0.5<<20 (524288 bytes = 0.5 Mb)
                "badger-max-table-size=524288",
                "badger-number-of-compactors=1",
                "badger-number-of-level-zero-tables=1",
                "badger-number-of-zero-tables-stall=2",
 ```
+
 - Memory consumption max limit: 2GB
-``` 
-               // 16<<20 (16777216 bytes = 16 Mb)              
+
+```
+               // 16<<20 (16777216 bytes = 16 Mb)
                "badger-max-table-size=16777216",
                "badger-number-of-compactors=1",
                "badger-number-of-level-zero-tables=1",
                "badger-number-of-zero-tables-stall=2",
 ```
+
 - Memory consumption max limit: 5GB
-``` 
-               // 32<<20 (33554432 bytes = 32 Mb)             
+
+```
+               // 32<<20 (33554432 bytes = 32 Mb)
                "badger-max-table-size=33554432",
                "badger-number-of-compactors=1",
                "badger-number-of-level-zero-tables=2",
                "badger-number-of-zero-tables-stall=3",
 ```
 
-Apart from the above settings, max-disk-mb and max-look-back can be tweaked according to input data and memory constraints.  
+Apart from the above settings, max-disk-mb and max-look-back can be tweaked according to input data and memory constraints.
+
+## Prometheus
+
+Sloop uses the [Prometheus](https://prometheus.io/) library to emit metrics, which is very helpful for performance debugging.
+
+In the root of the repo is a Prometheus config file
+[prometheus.yml](./prometheus.yml).
+
+On OSX you can install Prometheus with `brew install prometheus`. Then start it from the sloop directory by running `prometheus`
+
+Open your browser to http://localhost:9090.
+
+An example of a useful query is [rate(kubewatch_event_count[5m])](<http://localhost:9090/graph?g0.range_input=1h&g0.expr=rate(kubewatch_event_count%5B1m%5D)&g0.tab=0>)
+
 ## Contributing
 
 Refer to [CONTRIBUTING.md](CONTRIBUTING.md)<br>

--- a/go.mod
+++ b/go.mod
@@ -1,20 +1,13 @@
 module github.com/salesforce/sloop
 
-go 1.13
+go 1.19
 
 require (
-	cloud.google.com/go v0.49.0 // indirect
-	github.com/DataDog/zstd v1.4.5 // indirect
 	github.com/Jeffail/gabs/v2 v2.2.0
 	github.com/dgraph-io/badger/v2 v2.0.3
-	github.com/dgraph-io/ristretto v0.0.2 // indirect
-	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.4.3
-	github.com/googleapis/gnostic v0.3.1 // indirect
-	github.com/hashicorp/golang-lru v0.5.3 // indirect
-	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/jteeuwen/go-bindata v3.0.7+incompatible
 	github.com/nsf/jsondiff v0.0.0-20190712045011-8443391ee9b6
 	github.com/pkg/errors v0.9.1
@@ -22,11 +15,56 @@ require (
 	github.com/spf13/afero v1.2.2
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344
-	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6 // indirect
-	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
-	google.golang.org/appengine v1.6.5 // indirect
 	k8s.io/api v0.17.0
 	k8s.io/apiextensions-apiserver v0.17.0
 	k8s.io/apimachinery v0.17.0
 	k8s.io/client-go v0.17.0
+)
+
+require (
+	cloud.google.com/go v0.49.0 // indirect
+	github.com/Azure/go-autorest/autorest v0.9.0 // indirect
+	github.com/Azure/go-autorest/autorest/adal v0.5.0 // indirect
+	github.com/Azure/go-autorest/autorest/date v0.1.0 // indirect
+	github.com/Azure/go-autorest/logger v0.1.0 // indirect
+	github.com/Azure/go-autorest/tracing v0.5.0 // indirect
+	github.com/DataDog/zstd v1.4.5 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash v1.1.0 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgraph-io/ristretto v0.0.2 // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 // indirect
+	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/evanphx/json-patch v4.2.0+incompatible // indirect
+	github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/google/gofuzz v1.0.0 // indirect
+	github.com/googleapis/gnostic v0.3.1 // indirect
+	github.com/hashicorp/golang-lru v0.5.3 // indirect
+	github.com/imdario/mergo v0.3.8 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.26.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6 // indirect
+	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 // indirect
+	golang.org/x/text v0.3.2 // indirect
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
+	google.golang.org/appengine v1.6.5 // indirect
+	google.golang.org/protobuf v1.26.0-rc.1 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.3.0 // indirect
+	k8s.io/klog v1.0.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a // indirect
+	k8s.io/utils v0.0.0-20191114184206-e782cd3c129f // indirect
+	sigs.k8s.io/yaml v1.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -102,7 +102,6 @@ github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=


### PR DESCRIPTION
Closes #239 

Per the policy written here we would normally choose Go 1.18 however we have been running Sloop built with Go 1.19 internally for some time and are not in a position to retrospectively validate 1.18 is suitable.
On last check Kubernetes client-go requires Go 1.19.

- go.mod dictates GHA version
- go mod tidy
- add versioning policy to CONTRIBUTING guide
- move Prometheus to README as user related rather than contributing
- update Dockerfile