### PR TITLE
feat(helm): Uplift to Helm v3, various requests, tag latest image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,7 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           # generate Docker tags based on the following events/attributes
           tags: |
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}

--- a/helm/sloop/Chart.yaml
+++ b/helm/sloop/Chart.yaml
@@ -1,6 +1,6 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0"
 description: Sloop is a kubernetes history visualization tool.
 name: sloop
-version: 0.1.0
+version: 0.2.0
 icon: https://raw.githubusercontent.com/salesforce/sloop/master/other/sloop_logo_color.png

--- a/helm/sloop/templates/statefulset.yaml
+++ b/helm/sloop/templates/statefulset.yaml
@@ -74,6 +74,7 @@ spec:
           name: {{ .Values.name }}
         name: sloopconfig
       serviceAccountName: {{ .Values.serviceAccountName }}
+{{- if .Values.persistentVolume.enabled }}
   volumeClaimTemplates:
   - metadata:
      name: sloop-data
@@ -86,3 +87,4 @@ spec:
      resources:
        requests:
          storage: {{ .Values.persistentVolume.size }}
+{{- end }}

--- a/helm/sloop/templates/statefulset.yaml
+++ b/helm/sloop/templates/statefulset.yaml
@@ -66,6 +66,10 @@ spec:
           name: sloop-data
         - mountPath: /sloopconfig/
           name: sloopconfig
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
       - emptyDir:
           sizeLimit: {{ .Values.persistentVolume.sizeLimit }}

--- a/helm/sloop/values.yaml
+++ b/helm/sloop/values.yaml
@@ -10,6 +10,8 @@ image:
   tag: latest
   repository: ghcr.io/salesforce/sloop
   pullPolicy: IfNotPresent
+  # pullSecrets:
+  # - name: example-secret
 persistentVolume:
   # If false then an emptyDir will be used.
   enabled: true

--- a/helm/sloop/values.yaml
+++ b/helm/sloop/values.yaml
@@ -8,7 +8,7 @@ name: sloop
 replicas: 1
 image:
   tag: latest
-  repository: sloopimage/sloop
+  repository: ghcr.io/salesforce/sloop
   pullPolicy: IfNotPresent
 persistentVolume:
   ## If defined it will specify the storageClass for the statefulSet

--- a/helm/sloop/values.yaml
+++ b/helm/sloop/values.yaml
@@ -11,6 +11,8 @@ image:
   repository: ghcr.io/salesforce/sloop
   pullPolicy: IfNotPresent
 persistentVolume:
+  # If false then an emptyDir will be used.
+  enabled: true
   ## If defined it will specify the storageClass for the statefulSet
   ## If undefined it will use the cluster default (typically gp2 on AWS, standard on GKE)
   #  storageClass:


### PR DESCRIPTION
Typical practice is to tag the most recently built image with `latest`. Currently the project tags with `master` and others.
See: https://github.com/docker/metadata-action#latest-tag

For Helm changes, each one was tested one by one via: `helm template . | kubectl apply -f -`
Confirm Sloop comes up with expected change and then: `helm template . | kubectl delete -f -` to remove resources from the cluster.

Closes: #86 #165 #233  
