### PR TITLE
fix(ci): Correctly match and tag containers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,10 +28,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
             type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=match,pattern=(v\d+\.\d+)
             type=sha
 
       - name: Log in to GitHub Docker Registry


### PR DESCRIPTION
Release tags have been `vM.m` which wasn't being matched by the GHA `docker/metadata-action@v3` due to the `v` prefix. 
`v` prefix is common in many projects though.
```
Warning: v1.2 is not a valid semver. More info: https://semver.org/
```
See: https://github.com/docker/metadata-action#typesemver

I don't think a `vM` tag is useful so removed it.
This GHA only runs on tag or master branch push so generating a PR tag is unnecessary. Removed.

GHA log for `v1.2` tag push: https://github.com/salesforce/sloop/actions/runs/3651605823/jobs/6169012887

Closes #164 

Part of #245 "On git tag creation"