### PR TITLE
Add GHA workflow to lint helm chart, and fix a bug in the chart

### DIFF
--- a/.github/workflows/lint-helm-chart.yml
+++ b/.github/workflows/lint-helm-chart.yml
@@ -1,0 +1,32 @@
+name: Lint helm chart
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+          - 'helm/sloop/**'
+  pull_request:
+    branches:
+      - "*"
+    paths:
+          - 'helm/sloop/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'v3.12.0'
+
+      - name: Lint chart
+        run: |
+          helm lint helm/sloop

--- a/helm/sloop/templates/clusterrole.yaml
+++ b/helm/sloop/templates/clusterrole.yaml
@@ -91,7 +91,7 @@ rules:
 {{- with .Values.clusterRole.apiGroups }}
   - apiGroups:
 {{- range . }}
-      - {{ . }}
+      - {{ . | quote }}
 {{- end }}
     resources:
       - '*'


### PR DESCRIPTION
1. Valid apiGroup values, e.g. `*.mygroup.example.com`, must be quoted in the template.

    Before this change, `helm lint` failed with this error:

    `[ERROR] templates/clusterrole.yaml: unable to parse YAML: error converting YAML to JSON: yaml: line 92: did not find expected alphabetic or numeric character`

2. Adds an action to lint the helm chart whenever it is changed.

    Note: I've fixed the helm version at 3.12.0. If you'd like to always use the latest stable version, the action will need to use a GitHub token, as explained here: https://github.com/Azure/setup-helm#example