### PR TITLE
ci: Use a descriptive name for the job in the lint helm chart workflow

### DIFF
--- a/.github/workflows/lint-helm-chart.yml
+++ b/.github/workflows/lint-helm-chart.yml
@@ -13,7 +13,7 @@ on:
           - 'helm/sloop/**'
 
 jobs:
-  test:
+  lint-helm-chart:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Prior to this PR, both the test and lint helm chart workflows used the job name `test`,  which results in two identical lines in the summary, which can be confusing: 

![image](https://github.com/salesforce/sloop/assets/3445370/4127de74-a957-4138-9b80-dcdb7e03e2d3)

(Sorry, I didn't notice this when I created #262.)