### PR TITLE
add mutating webhook configurations in sloop

### DIFF
--- a/pkg/sloop/ingress/kubewatcher.go
+++ b/pkg/sloop/ingress/kubewatcher.go
@@ -126,6 +126,7 @@ func (i *kubeWatcherImpl) startWellKnownInformers(kubeclient kubernetes.Interfac
 	i.informerFactory.Core().V1().Services().Informer().AddEventHandler(i.getEventHandlerForResource("Service", enableGranularMetrics))
 	i.informerFactory.Core().V1().ReplicationControllers().Informer().AddEventHandler(i.getEventHandlerForResource("ReplicationController", enableGranularMetrics))
 	i.informerFactory.Storage().V1().StorageClasses().Informer().AddEventHandler(i.getEventHandlerForResource("StorageClass", enableGranularMetrics))
+	i.informerFactory.Admissionregistration().V1().MutatingWebhookConfigurations().Informer().AddEventHandler(i.getEventHandlerForResource("MutatingWebhookConfiguration", enableGranularMetrics))
 	i.informerFactory.Start(i.stopChan)
 }
 


### PR DESCRIPTION
Sloop doesn't support mutating webhook configurations currently. Adding an informer so users can filter on mutating webhook configurations.

Tested locally:
<img width="1136" height="689" alt="image" src="https://github.com/user-attachments/assets/f6dec72d-bce3-49fa-a581-df728035b1e7" />
