### PR TITLE
@W-21199400:adding-log-levels

### DIFF
--- a/pkg/sloop/common/logging.go
+++ b/pkg/sloop/common/logging.go
@@ -1,0 +1,11 @@
+
+package common
+
+import "github.com/golang/glog"
+
+// Log verbosity levels for use with glog.V()
+const (
+	LogLevelInfo  glog.Level = 1
+	LogLevelDebug glog.Level = 2
+	LogLevelTrace glog.Level = 3
+)

--- a/pkg/sloop/kubeextractor/events.go
+++ b/pkg/sloop/kubeextractor/events.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/salesforce/sloop/pkg/sloop/common"
 )
 
 // Example Event
@@ -91,14 +92,14 @@ func ExtractEventInfo(payload string) (*EventInfo, error) {
 
 	fs, err := time.Parse(time.RFC3339, internalResource.FirstTimestamp)
 	if err != nil {
-		glog.Errorf("Could not parse first timestamp %v\n", internalResource.FirstTimestamp)
+		glog.V(common.LogLevelDebug).Infof("Could not parse first timestamp %v", internalResource.FirstTimestamp)
 		fs = time.Time{}
 	}
 
 	ls, err := time.Parse(time.RFC3339, internalResource.LastTimestamp)
 	if err != nil {
-		glog.Errorf("Could not parse last timestamp %v\n", internalResource.LastTimestamp)
-		fs = time.Time{}
+		glog.V(common.LogLevelDebug).Infof("Could not parse last timestamp %v", internalResource.LastTimestamp)
+		ls = time.Time{}
 	}
 
 	return &EventInfo{

--- a/pkg/sloop/server/internal/config/config.go
+++ b/pkg/sloop/server/internal/config/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 
+	"github.com/salesforce/sloop/pkg/sloop/common"
 	"github.com/salesforce/sloop/pkg/sloop/server/server_metrics"
 	"github.com/salesforce/sloop/pkg/sloop/webserver"
 )
@@ -257,17 +258,17 @@ func loadFromFile(filename string, config *SloopConfig) *SloopConfig {
 func getConfigFilePath() string {
 	configFileFlag := getConfigFlag()
 	if configFileFlag != "" {
-		glog.Infof("Config flag: %s", configFileFlag)
+		glog.V(common.LogLevelDebug).Infof("Config flag: %s", configFileFlag)
 		return configFileFlag
 	}
 
 	configFileOS := os.Getenv(sloopConfigEnvVar)
 	if configFileOS != "" {
-		glog.Infof("Config env: %s", configFileOS)
+		glog.V(common.LogLevelDebug).Infof("Config env: %s", configFileOS)
 		return configFileOS
 	}
 
-	glog.Infof("Default config set")
+	glog.V(common.LogLevelDebug).Info("Default config set")
 	return ""
 }
 


### PR DESCRIPTION
This change introduces explicit log verbosity levels to sloop to mitigate log-flooding issues. Currently, certain events—specifically date/time parsing failures—are being logged at a high frequency. This constant posting to the logs creates significant memory pressure and makes it difficult to monitor actual system health.

By moving these specific logs to LogLevelDebug (V2), we reduce the overhead on the logging subsystem while still allowing for deep troubleshooting when needed.
