### PR TITLE
Bump Go builder image to 1.23, add docker-build target, minor fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19 as build
+FROM golang:1.23 AS build
 RUN apt-get update && apt-get install -y curl make
 
 # https://github.com/kubernetes-sigs/aws-iam-authenticator/releases

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY:all run linux docker generate tidy protobuf cover docker-push
+.PHONY:all run linux docker docker-build generate tidy protobuf cover docker-push
 
 all:
 	go get ./pkg/...
@@ -19,10 +19,13 @@ goreleaser:
    	 fi
 
 docker-snapshot: goreleaser
-	$(GOPATH)/bin/goreleaser release --snapshot --rm-dist
+	$(GOPATH)/bin/goreleaser release --snapshot --clean
+
+docker-build:
+	docker build -t salesforce/sloop:latest .
 
 docker: goreleaser
-	$(GOPATH)/bin/goreleaser release --rm-dist --skip-publish
+	$(GOPATH)/bin/goreleaser release --clean --skip-publish
 
 generate:
 	go generate ./pkg/...

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Other makefile targets:
 To run from Docker you need to host mount your kubeconfig:
 
 ```shell script
-make docker-snapshot
-docker run --rm -it -p 8080:8080 -v ~/.kube/:/kube/ -e KUBECONFIG=/kube/config sloop
+make docker-build
+docker run --rm -it -p 8080:8080 -v ~/.kube/:/kube/ -e KUBECONFIG=/kube/config salesforce/sloop:latest
 ```
 
 In this mode, data is written to a memory-backed volume and is discarded after each run. To preserve the data, you can host-mount /data with something like `-v /data/:/some_path_on_host/`

--- a/pkg/sloop/common/logging.go
+++ b/pkg/sloop/common/logging.go
@@ -1,4 +1,3 @@
-
 package common
 
 import "github.com/golang/glog"

--- a/pkg/sloop/ingress/kubeclient.go
+++ b/pkg/sloop/ingress/kubeclient.go
@@ -54,6 +54,10 @@ func MakeKubernetesClient(masterURL string, kubeContext string, privilegedAccess
 	if privilegedAccess {
 		clientConfig := getConfig(masterURL, kubeContext)
 		config, err = ClientConfig(clientConfig)
+		if err != nil {
+			glog.Errorf("Cannot create config from client config: %v", err)
+			return nil, err
+		}
 		glog.Infof("Building k8sclient with context=%v, masterURL=%v, configFile=%v.", kubeContext, config.Host, clientConfig.ConfigAccess().GetLoadingPrecedence())
 	} else {
 		glog.Infof("Creating Config using BuildConfigFromFlags")


### PR DESCRIPTION
**What this PR does / why we need it**:

- Bump Dockerfile Go builder image from 1.19 to 1.23 (1.19 is EOL with known CVEs)
- Add `docker-build` Makefile target for building the image directly from repo root
- Update deprecated goreleaser `--rm-dist` flag to `--clean`
- Add missing error check after `ClientConfig()` in `kubeclient.go` (prevents nil-pointer panic)
- Update README Docker instructions to use new target and correct image tag

**Which issue(s) this PR fixes**:
Fixes #288

**Special notes**:

Existing `docker-snapshot` and `docker` Makefile targets are unchanged — they still use goreleaser. The new `docker-build` target is a standalone alternative.

**Tests**:

- [x] `make docker-build` builds successfully
- [x] All Go tests pass during build
- [x] Container starts and serves UI on localhost:8080

**PR Checklist**:

- [x] Design — minimal changes, no architectural shift
- [x] Functionality — verified Docker build and container runtime
- [x] Tests — all existing tests pass during build
- [x] Naming — follows existing Makefile target conventions
- [x] Comments — no new comments needed